### PR TITLE
Fix diff drive plugin because of deprecation of legacyMode

### DIFF
--- a/ca_description/urdf/create_base_gazebo.urdf.xacro
+++ b/ca_description/urdf/create_base_gazebo.urdf.xacro
@@ -20,7 +20,7 @@
         <publishWheelTF>true</publishWheelTF>
         <publishOdomTF>true</publishOdomTF>
         <publishWheelJointState>true</publishWheelJointState>
-        <legacyMode>true</legacyMode>
+        <legacyMode>false</legacyMode>
         <odometrySource>world</odometrySource>
         <publishTf>1</publishTf>
       </plugin>

--- a/ca_description/urdf/create_wheel.xacro
+++ b/ca_description/urdf/create_wheel.xacro
@@ -34,7 +34,7 @@
     <origin xyz="${x} ${y} ${z}" rpy="0 0 0" />
     <parent link="base_link" />
     <child link="${prefix}_wheel_link" />
-    <axis xyz="0 1 0" />
+    <axis xyz="0 -1 0" />
   </joint>
 </xacro:macro>
 


### PR DESCRIPTION
This is because of the `legacyMode` deprecation tag introduced in ROS Melodic. See [this commit](https://github.com/ros-simulation/gazebo_ros_pkgs/commit/2eb6dcbc91fc346ce76251e3730fc152d6a9c3d7#diff-16ccb19dacd70f56ecfea610b31fefb0).