### PR TITLE
Change GPG keys for ROS

### DIFF
--- a/docker/create_ros_kinetic/Dockerfile
+++ b/docker/create_ros_kinetic/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
 
 # Setup keys for ROS
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # Install ROS packages
 RUN apt-get update

--- a/docker/create_ros_melodic/Dockerfile
+++ b/docker/create_ros_melodic/Dockerfile
@@ -9,7 +9,7 @@ USER root
 RUN echo "deb http://packages.ros.org/ros/ubuntu $(lsb_release -sc) main" > /etc/apt/sources.list.d/ros-latest.list
 
 # Setup keys for ROS
-RUN apt-key adv --keyserver hkp://ha.pool.sks-keyservers.net:80 --recv-key 421C365BD9FF1F717815A3895523BAEEB01FA116
+RUN apt-key adv --keyserver 'hkp://keyserver.ubuntu.com:80' --recv-key C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
 
 # Install ROS packages
 RUN apt-get update && \


### PR DESCRIPTION
According to [this ROS Discourse thread](https://discourse.ros.org/t/new-gpg-keys-deployed-for-packages-ros-org/9454), GPG keys must be changed.