### PR TITLE
Add several fixes

### DIFF
--- a/ca_description/README.md
+++ b/ca_description/README.md
@@ -15,7 +15,7 @@ To convert the xacro file into a URDF file:
 ```bash
 roscd ca_description/urdf/
 roscore &
-rosrun xacro xacro --inorder create_2.xacro [ARGS] > test.urdf
+rosrun xacro xacro create_2.xacro [ARGS] > test.urdf
 ```
 
 Replace [ARGS] with the corresponding XACRO arguments. As an example, `visualize:=false`.

--- a/ca_description/launch/create_description.launch
+++ b/ca_description/launch/create_description.launch
@@ -10,7 +10,7 @@
 
   <!-- Robot description -->
   <arg name="xacro_args" value="visualize:=$(arg visualize)"/>
-  <param name="robot_description" command="$(find xacro)/xacro --inorder $(arg model) $(arg xacro_args)"/>
+  <param name="robot_description" command="$(find xacro)/xacro $(arg model) $(arg xacro_args)"/>
   <!-- Robot state publisher-->
   <node name="robot_state_publisher" pkg="robot_state_publisher" type="robot_state_publisher" output="screen">
     <param name="publish_frequency" type="double" value="$(arg freq)" />

--- a/ca_description/urdf/create_base.xacro
+++ b/ca_description/urdf/create_base.xacro
@@ -15,6 +15,15 @@
     <xacro:property name="base_height" value="0.0611632"/>
     <xacro:property name="base_mass" value="2"/>
 
+    <!-- The root link base_footprint has an inertia specified in the URDF,
+         but KDL does not support a root link with an inertia.
+         As a workaround, you can add an extra dummy link to your URDF. -->
+    <joint name="fixed_joint" type="fixed">
+      <parent link="dummy_link"/>
+      <child link="base_footprint"/>
+    </joint>
+    <link name="dummy_link"/>
+
     <link name="base_footprint">
       <xacro:dummy_inertia/>
     </link>

--- a/ca_description/urdf/create_base_gazebo.xacro
+++ b/ca_description/urdf/create_base_gazebo.xacro
@@ -26,7 +26,7 @@
         <publishOdomTF>true</publishOdomTF>
         <publishWheelJointState>true</publishWheelJointState>
         <legacyMode>false</legacyMode>
-        <odometrySource>map</odometrySource>
+        <odometrySource>encoder</odometrySource>
         <publishTf>1</publishTf>
       </plugin>
 
@@ -37,7 +37,7 @@
         <bodyName>base_link</bodyName>
         <topicName>gts</topicName>
         <gaussianNoise>0</gaussianNoise>
-        <frameName>/map</frameName>
+        <frameName>map</frameName>
         <xyzOffsets>0 0 0</xyzOffsets>
         <rpyOffsets>0 0 0</rpyOffsets>
       </plugin>

--- a/ca_gazebo/launch/spawn_multirobot.launch
+++ b/ca_gazebo/launch/spawn_multirobot.launch
@@ -1,7 +1,7 @@
 <launch>
   <!-- https://answers.ros.org/question/229489/how-do-i-create-dynamic-launch-files/ -->
   <arg name="nr" default="$(optenv NUM_ROBOTS 1)"/>
-  <arg name="rviz" default="$(optenv RVIZ true)"/>
+  <arg name="rviz" default="$(optenv RVIZ false)"/>
   <arg name="localization" default="$(optenv LOCALIZATION none)"/>
 
   <!-- Start 1 robot -->

--- a/ca_gazebo/launch/spawn_multirobot.launch
+++ b/ca_gazebo/launch/spawn_multirobot.launch
@@ -20,9 +20,14 @@
       <arg name="localization" value="$(arg localization)"/>
     </include>
 
+    <arg if ="$(eval 'localization' == 'amcl')" name="rviz_config" value="localization"/>
+    <arg if ="$(eval 'localization' == 'none')" name="rviz_config" value="robot_description"/>
+    <arg if ="$(eval 'localization' == 'slam')" name="rviz_config" value="navigation"/>
+    <arg if ="$(eval 'nr' > 1)"                 name="rviz_config" value="multi_robot"/>
+
     <!-- RViz -->
     <include if="$(arg rviz)" file="$(find ca_tools)/launch/rviz.launch">
-      <arg name="config_file" value="$(find ca_tools)/rviz/swarm.rviz"/>
+      <arg name="config_file" value="$(find ca_tools)/rviz/$(arg rviz_config).rviz"/>
     </include>
   </group>
 

--- a/docker/create_melodic_nvidia/Dockerfile
+++ b/docker/create_melodic_nvidia/Dockerfile
@@ -13,9 +13,8 @@ COPY --from=nvidia /etc/ld.so.conf.d/glvnd.conf /etc/ld.so.conf.d/glvnd.conf
 ENV NVIDIA_VISIBLE_DEVICES=all NVIDIA_DRIVER_CAPABILITIES=all
 
 USER root
-RUN apt-get update
-
-RUN apt-get install -y \
+RUN apt-get update && \
+  apt-get install -y \
   ros-${ROS1_DISTRO}-dwa-local-planner \
   ros-${ROS1_DISTRO}-image-proc \
   ros-${ROS1_DISTRO}-joy \
@@ -28,3 +27,4 @@ RUN apt-get install -y \
   ros-${ROS1_DISTRO}-smach-viewer
 
 USER create
+CMD bash

--- a/docker/create_ros_melodic/Dockerfile
+++ b/docker/create_ros_melodic/Dockerfile
@@ -64,5 +64,3 @@ RUN mkdir -p /create_ws/src/ && \
 USER create
 WORKDIR /create_ws/
 RUN rosdep update
-
-CMD tmux

--- a/docker/create_ros_melodic_gazebo9/Dockerfile
+++ b/docker/create_ros_melodic_gazebo9/Dockerfile
@@ -19,4 +19,3 @@ RUN apt-get update && \
     ros-$ROS1_DISTRO-gazebo-ros-control
 
 USER create
-CMD tmux

--- a/docker/create_ubuntu_bionic/Dockerfile
+++ b/docker/create_ubuntu_bionic/Dockerfile
@@ -41,5 +41,3 @@ RUN adduser --gecos "Development User" --disabled-password -u ${uid} create
 RUN adduser create sudo
 RUN echo '%sudo ALL=(ALL) NOPASSWD:ALL' >> /etc/sudoers
 USER root
-
-CMD tmux

--- a/docker/launch_docker.sh
+++ b/docker/launch_docker.sh
@@ -19,8 +19,8 @@ if [[ $IMAGE_NAME = *"nvidia"* ]]; then
 fi
 
 xhost +
-docker run -it \
-    --privileged --rm \
+docker run -it --rm \
+    --privileged \
     "--ipc=host" \
     "--cap-add=IPC_LOCK" \
     "--cap-add=sys_nice" \
@@ -34,3 +34,5 @@ docker run -it \
     -e ROS_MASTER_URI=http://localhost:11311 \
     $NVIDIA_FLAG \
     $IMAGE_NAME
+
+xhost -

--- a/navigation/ca_move_base/config/costmap_common_params.yaml
+++ b/navigation/ca_move_base/config/costmap_common_params.yaml
@@ -1,5 +1,3 @@
-robot_base_frame: base_link
-
 transform_tolerance: 0.5
 
 robot_radius: 0.18

--- a/navigation/ca_move_base/config/dwa_local_planner_params.yaml
+++ b/navigation/ca_move_base/config/dwa_local_planner_params.yaml
@@ -7,17 +7,17 @@ DWAPlannerROS:
   max_vel_y: 0.0  # diff drive robot
   min_vel_y: 0.0  # diff drive robot
 
-  max_trans_vel: 0.25 # choose slightly less than the base's capability
-  min_trans_vel: 0.1  # this is the min trans velocity when there is negligible rotational velocity
+  max_vel_trans: 0.25 # choose slightly less than the base's capability
+  min_vel_trans: 0.1  # this is the min trans velocity when there is negligible rotational velocity
   trans_stopped_vel: 0.1
 
   # Warning!
   #   do not set min_trans_vel to 0.0 otherwise dwa will always think translational velocities
   #   are non-negligible and small in place rotational velocities will be created.
 
-  max_rot_vel: 1.5  # choose slightly less than the base's capability
-  min_rot_vel: 0.4  # this is the min angular velocity when there is negligible translational velocity
-  rot_stopped_vel: 0.4
+  max_vel_theta: 1.5  # choose slightly less than the base's capability
+  min_vel_theta: 0.4  # this is the min angular velocity when there is negligible translational velocity
+  theta_stopped_vel: 0.4
 
   acc_lim_x: 0.8
   acc_lim_theta: 2.0

--- a/navigation/ca_move_base/config/global_costmap_params.yaml
+++ b/navigation/ca_move_base/config/global_costmap_params.yaml
@@ -1,6 +1,10 @@
 global_costmap:
-  global_frame: /map
+  global_frame: map
+
+  plugins:
+    - {name: static_layer, type: "costmap_2d::StaticLayer" }
+    - {name: obstacle_layer, type: "costmap_2d::ObstacleLayer" }
+    - {name: inflation_layer,  type: "costmap_2d::InflationLayer" }
 
   update_frequency: 5.0
   publish_frequency: 0.0
-  static_map: true

--- a/navigation/ca_move_base/config/local_costmap_params.yaml
+++ b/navigation/ca_move_base/config/local_costmap_params.yaml
@@ -1,10 +1,12 @@
 local_costmap:
-  global_frame: odom
+
+  plugins:
+    - {name: obstacle_layer,  type: "costmap_2d::ObstacleLayer" }
+    - {name: inflation_layer,  type: "costmap_2d::InflationLayer" }
 
   rolling_window: true
   publish_frequency: 2.0
   update_frequency: 5.0
-  static_map: false
 
   width: 2.5
   height: 2.5

--- a/navigation/ca_move_base/launch/amcl.launch
+++ b/navigation/ca_move_base/launch/amcl.launch
@@ -10,7 +10,7 @@
     <remap from="scan" to="laser/scan"/>
     <param name="odom_frame_id" value="$(arg ns)_tf/odom"/>
     <param name="base_frame_id" value="$(arg ns)_tf/base_link"/>
-    <param name="global_frame_id" value="/map"/>
+    <param name="global_frame_id" value="map"/>
   </node>
   
 </launch>

--- a/navigation/ca_move_base/launch/map_server.launch
+++ b/navigation/ca_move_base/launch/map_server.launch
@@ -4,6 +4,6 @@
   
   <!-- Run the map server node with a predefined map -->
   <node name="map_server" pkg="map_server" type="map_server" args="$(arg map_file)">
-    <param name="frame_id" value="/map"/>
+    <param name="frame_id" value="map"/>
   </node>
 </launch>

--- a/navigation/ca_move_base/launch/move_base.launch
+++ b/navigation/ca_move_base/launch/move_base.launch
@@ -16,10 +16,13 @@
 
     <!-- We want a single map for multi-robots -->
     <remap from="map" to="/map"/>
-    <!-- TODO: WHY WAS THIS HACK NECESSARY? -->
     <remap from="/laser/scan" to="laser/scan"/>
     <remap from="/mobile_base/sensors/bumper_pointcloud" 
            to="mobile_base/sensors/bumper_pointcloud"/>
+    <!-- Remap frames for specific robots -->
+    <param name="local_costmap/robot_base_frame" value="$(arg ns)_tf/base_link"/>
+    <param name="global_costmap/robot_base_frame" value="$(arg ns)_tf/base_link"/>
+    <param name="local_costmap/global_frame" value="$(arg ns)_tf/odom"/>
   </node>
 
 </launch>

--- a/navigation/ca_move_base/src/send_robot_goal.cpp
+++ b/navigation/ca_move_base/src/send_robot_goal.cpp
@@ -21,7 +21,7 @@ int main(int argc, char** argv){
 
 	move_base_msgs::MoveBaseGoal goal;
 
-	goal.target_pose.header.frame_id = "/map";
+	goal.target_pose.header.frame_id = "map";
 	goal.target_pose.header.stamp = ros::Time::now();
 	try{
 		goal.target_pose.pose.position.x = atof(argv[1]);

--- a/navigation/ca_slam/config/slam_gmapping.yaml
+++ b/navigation/ca_slam/config/slam_gmapping.yaml
@@ -1,5 +1,3 @@
-map_frame: "/map"
-
 map_update_interval: "5.0"
 maxUrange: "6.0"
 maxRange: "8.0"

--- a/navigation/ca_slam/launch/slam_gmapping.launch
+++ b/navigation/ca_slam/launch/slam_gmapping.launch
@@ -11,5 +11,6 @@
     
     <param name="odom_frame" value="$(arg ns)_tf/odom"/>
     <param name="base_frame" value="$(arg ns)_tf/base_footprint"/>
+    <param name="map_frame" value="map"/>
   </node>
 </launch>

--- a/navigation/ca_swarm/config/dwa_local_planner_params.yaml
+++ b/navigation/ca_swarm/config/dwa_local_planner_params.yaml
@@ -7,17 +7,17 @@ DWAPlannerROS:
   max_vel_y: 0.0  # diff drive robot
   min_vel_y: 0.0  # diff drive robot
 
-  max_trans_vel: 0.25 # choose slightly less than the base's capability
-  min_trans_vel: 0.1  # this is the min trans velocity when there is negligible rotational velocity
+  max_vel_trans: 0.25 # choose slightly less than the base's capability
+  min_vel_trans: 0.1  # this is the min trans velocity when there is negligible rotational velocity
   trans_stopped_vel: 0.1
 
   # Warning!
   #   do not set min_trans_vel to 0.0 otherwise dwa will always think translational velocities
   #   are non-negligible and small in place rotational velocities will be created.
 
-  max_rot_vel: 1.5  # choose slightly less than the base's capability
-  min_rot_vel: 0.4  # this is the min angular velocity when there is negligible translational velocity
-  rot_stopped_vel: 0.4
+  max_vel_theta: 1.5  # choose slightly less than the base's capability
+  min_vel_theta: 0.4  # this is the min angular velocity when there is negligible translational velocity
+  theta_stopped_vel: 0.4
 
   acc_lim_x: 0.8
   acc_lim_theta: 2.0

--- a/navigation/ca_swarm/config/dwa_local_planner_params.yaml
+++ b/navigation/ca_swarm/config/dwa_local_planner_params.yaml
@@ -49,7 +49,7 @@ DWAPlannerROS:
 # Debugging
   publish_traj_pc : true
   publish_cost_grid_pc: true
-  global_frame_id: /map
+  global_frame_id: map
 
 
 # Differential-drive robot configuration - necessary?

--- a/navigation/ca_swarm/config/global_costmap_params.yaml
+++ b/navigation/ca_swarm/config/global_costmap_params.yaml
@@ -1,6 +1,11 @@
 global_costmap:
   global_frame: map
 
+  plugins:
+    - {name: static_layer, type: "costmap_2d::StaticLayer" }
+    - {name: obstacle_layer, type: "costmap_2d::ObstacleLayer" }
+    - {name: inflation_layer,  type: "costmap_2d::InflationLayer" }
+
   update_frequency: 5.0
   publish_frequency: 0.0
   static_map: true

--- a/navigation/ca_swarm/config/global_costmap_params.yaml
+++ b/navigation/ca_swarm/config/global_costmap_params.yaml
@@ -1,5 +1,5 @@
 global_costmap:
-  global_frame: /map
+  global_frame: map
 
   update_frequency: 5.0
   publish_frequency: 0.0

--- a/navigation/ca_swarm/config/local_costmap_params.yaml
+++ b/navigation/ca_swarm/config/local_costmap_params.yaml
@@ -1,6 +1,10 @@
 local_costmap:
   global_frame: map
 
+  plugins:
+    - {name: obstacle_layer,  type: "costmap_2d::ObstacleLayer" }
+    - {name: inflation_layer,  type: "costmap_2d::InflationLayer" }
+
   rolling_window: true
   publish_frequency: 2.0
   update_frequency: 5.0

--- a/navigation/ca_swarm/config/local_costmap_params.yaml
+++ b/navigation/ca_swarm/config/local_costmap_params.yaml
@@ -1,5 +1,5 @@
 local_costmap:
-  global_frame: /map
+  global_frame: map
 
   rolling_window: true
   publish_frequency: 2.0


### PR DESCRIPTION
This PR includes the following fixes:

- Delete `--inorder` flag, deprecated in ROS Melodic
- Suppress warning for invalid parent link
- Use `map` instead of `/map` for the link name
- Use `RVIZ=false` by default
- Don't open tmux by default
- Fixed navigation warnings since ROS Hydro