### PR TITLE
Changes from April 12th

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -45,7 +45,7 @@ script:
   # NOTE: GAZEBO TESTS FAIL IN PARALLEL
   - catkin_make run_tests -j1 && catkin_test_results
   # Lint package files ONLY for create_autonomy
-  - sudo apt-get install python-catkin-lint
+  - sudo apt-get install -y python-catkin-lint
   - catkin lint -W2 --strict --explain $CREATE_AUTONOMY_SRC --ignore plugin_missing_install --ignore target_name_collision
   # Tips
   #

--- a/ca_description/urdf/common_properties.xacro
+++ b/ca_description/urdf/common_properties.xacro
@@ -65,6 +65,7 @@
     </inertial>
   </xacro:macro>
 
-  <xacro:property name="cm_to_meters" value="${1./100.}"/>
+  <xacro:property name="cm_to_m" value="${1./100.}"/>
+  <xacro:property name="in_to_m" value="0.0254"/>
 
 </robot>

--- a/ca_description/urdf/create_base.xacro
+++ b/ca_description/urdf/create_base.xacro
@@ -3,12 +3,13 @@
 
   <xacro:include filename="$(find ca_description)/urdf/common_properties.xacro"/>
   <xacro:include filename="$(find ca_description)/urdf/create_base_gazebo.xacro"/>
+  <xacro:include filename="$(find ca_description)/urdf/create_battery.xacro"/>
   <xacro:include filename="$(find ca_description)/urdf/create_caster_wheel.xacro"/>
   <xacro:include filename="$(find ca_description)/urdf/create_wheel.xacro"/>
-  <xacro:include filename="$(find ca_description)/urdf/sensors/imu_sensor.xacro"/>
-  <xacro:include filename="$(find ca_description)/urdf/sensors/wall_sensor.xacro"/>
   <xacro:include filename="$(find ca_description)/urdf/sensors/cliff_sensors.xacro"/>
+  <xacro:include filename="$(find ca_description)/urdf/sensors/imu_sensor.xacro"/>
   <xacro:include filename="$(find ca_description)/urdf/sensors/omni_sensor.xacro"/>
+  <xacro:include filename="$(find ca_description)/urdf/sensors/wall_sensor.xacro"/>
 
   <xacro:macro name="create_base" params="wheel_separation wheel_radius wheel_width base_diameter *mesh">
 
@@ -96,6 +97,10 @@
     <xacro:caster_wheel radius="${caster_radius}">
       <origin xyz="0.13 0 ${caster_z}"/>
     </xacro:caster_wheel>
+
+    <xacro:battery>
+      <origin xyz="0.085 0 ${base_height}"/>
+    </xacro:battery>
 
     <!-- Simulation sensors -->
     <xacro:sim_create_base/>

--- a/ca_description/urdf/create_battery.xacro
+++ b/ca_description/urdf/create_battery.xacro
@@ -1,0 +1,40 @@
+<?xml version="1.0" ?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+<xacro:macro name="battery" params="name:=battery parent:=base_footprint *origin">
+
+  <xacro:include filename="$(find ca_description)/urdf/common_properties.xacro"/>
+
+  <xacro:property name="parent_link" value="${parent}"/>
+  <xacro:property name="link_name"   value="${name}_link"/>
+
+  <xacro:property name="mass"        value="1"/>
+  <xacro:property name="size_x_in"   value="2.2"/>
+  <xacro:property name="size_y_in"   value="5.7"/>
+  <xacro:property name="size_z_in"   value="2.5"/>
+
+  <joint name="${name}_joint" type="fixed">
+    <xacro:insert_block name="origin"/>
+    <parent link="${parent_link}"/>
+    <child link="${link_name}"/>
+  </joint>
+
+  <link name="${link_name}">
+    <xacro:inertial_cuboid mass="${mass}"
+                           x_length="${size_x_in*in_to_m}"
+                           y_length="${size_y_in*in_to_m}"
+                           z_length="${size_z_in*in_to_m}"/>
+    <visual>
+      <geometry>
+        <box size="${size_x_in*in_to_m} ${size_y_in*in_to_m} ${size_z_in*in_to_m}"/>
+      </geometry>
+    </visual>
+  </link>
+
+  <gazebo reference="${link_name}">
+    <material>Gazebo/ZincYellow</material>
+  </gazebo>
+
+</xacro:macro>
+
+</robot>

--- a/ca_description/urdf/create_caster_wheel.xacro
+++ b/ca_description/urdf/create_caster_wheel.xacro
@@ -7,7 +7,7 @@
 
   <xacro:property name="parent_link" value="${parent}"/>
   <xacro:property name="link_name"   value="${name}_link"/>
-  <xacro:property name="mass"        value="1"/>
+  <xacro:property name="mass"        value="0.2"/>
 
   <!-- fixed because there's no transmission -->
   <joint name="front_castor_joint" type="fixed">

--- a/ca_description/urdf/sensors/cliff_sensors.xacro
+++ b/ca_description/urdf/sensors/cliff_sensors.xacro
@@ -38,15 +38,15 @@
           </horizontal>
         </scan>
         <range>
-          <min>${min_range_cm*cm_to_meters}</min>
-          <max>${max_range_cm*cm_to_meters}</max>
-          <resolution>${resolution_cm*cm_to_meters}</resolution>
+          <min>${min_range_cm*cm_to_m}</min>
+          <max>${max_range_cm*cm_to_m}</max>
+          <resolution>${resolution_cm*cm_to_m}</resolution>
         </range>
       </ray>
       <plugin name="gazebo_ros_${name}" filename="libcreate_cliff_plugin.so">
         <topicName>${name}/raw</topicName>
         <frameName>${link_name}</frameName>
-        <cliffValue>${min_cliff_value_cm*cm_to_meters}</cliffValue>
+        <cliffValue>${min_cliff_value_cm*cm_to_m}</cliffValue>
       </plugin>
     </sensor>
   </gazebo>

--- a/ca_gazebo/CMakeLists.txt
+++ b/ca_gazebo/CMakeLists.txt
@@ -237,4 +237,5 @@ if(CATKIN_ENABLE_TESTING)
   # Tests list
   add_rostest(test/hz.test)
   add_rostest(test/publish.test)
+  add_rostest(test/static.test)
 endif()

--- a/ca_gazebo/CMakeLists.txt
+++ b/ca_gazebo/CMakeLists.txt
@@ -220,6 +220,11 @@ install(TARGETS
   RUNTIME DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
 )
 
+install(DIRECTORY scripts
+        DESTINATION ${CATKIN_PACKAGE_BIN_DESTINATION}
+        USE_SOURCE_PERMISSIONS
+)
+
 #############
 ## Testing ##
 #############

--- a/ca_gazebo/launch/create_empty_world.launch
+++ b/ca_gazebo/launch/create_empty_world.launch
@@ -18,11 +18,11 @@
 	</include>
 
 	<group if="$(eval arg('env')=='empty')">
-			<param name="create1/amcl/initial_pose_x" value="-3"/>
-			<param name="create1/amcl/initial_pose_y" value="4"/>
+			<param name="create1/amcl/initial_pose_x" value="0"/>
+			<param name="create1/amcl/initial_pose_y" value="0"/>
 			<param name="create1/amcl/initial_pose_a" value="0"/>
-			<param name="create2/amcl/initial_pose_x" value="5"/>
-			<param name="create2/amcl/initial_pose_y" value="1"/>
+			<param name="create2/amcl/initial_pose_x" value="2"/>
+			<param name="create2/amcl/initial_pose_y" value="0"/>
 			<param name="create2/amcl/initial_pose_a" value="1.5708"/>
 	</group>
 

--- a/ca_gazebo/scripts/set_properties
+++ b/ca_gazebo/scripts/set_properties
@@ -1,0 +1,43 @@
+#!/usr/bin/env python
+import rospy
+
+from gazebo_msgs.srv import GetPhysicsProperties, SetPhysicsProperties
+
+__author__ = 'Emiliano Borghi'
+
+class GazeboPhysicsProperties():
+
+  def __init__(self):
+    try:
+      rospy.init_node("gazebo_physics_properties", log_level=rospy.INFO)
+    except ROSInitException as e:
+      print("ROS node already initialized: {}".format(e))
+    finally:
+      # Get parameters
+      rtf = rospy.get_param('~real_time_factor', 1)
+      if rtf < 0:
+        rtf = 1
+      # Wait for Gazebo services
+      rospy.wait_for_service('gazebo/get_physics_properties')
+      rospy.wait_for_service('gazebo/set_physics_properties')
+      try:
+        # Get current physics properties
+        get_physics_properties_proxy = rospy.ServiceProxy('gazebo/get_physics_properties', GetPhysicsProperties)
+
+        # Changing max_step_size = RTF / time_step
+        rospy.loginfo("Setting RTF={}x".format(rtf))
+        max_step_size = rtf / get_physics_properties_proxy().time_step
+
+        # Set new physics properties
+        set_physics_properties_proxy = rospy.ServiceProxy('gazebo/set_physics_properties', SetPhysicsProperties)
+        set_physics_properties_proxy(
+          get_physics_properties_proxy().time_step,
+          max_step_size,
+          get_physics_properties_proxy().gravity,
+          get_physics_properties_proxy().ode_config
+        )
+      except rospy.ServiceException as e:
+        rospy.logerr("GazeboPhysicsProperties failed: {}".format(e))
+
+if __name__ == '__main__':
+  GazeboPhysicsProperties()

--- a/ca_gazebo/test/publish.test
+++ b/ca_gazebo/test/publish.test
@@ -5,6 +5,12 @@
     <arg name="gui" value="$(arg gui)"/>
   </include>
 
+  <!-- Change real-time factor of Gazebo -->
+  <node pkg="ca_gazebo" type="set_properties" name="gazebo_physics_properties" output="screen">
+    <param name="real_time_factor" value="10"/>
+  </node>
+
+  <!-- State machine to move the robot autonomously -->
   <include file="$(find ca_node)/launch/state_machine.launch"/>
 
   <test test-name="publishtest" name="publishtest"

--- a/ca_gazebo/test/scripts/publish.py
+++ b/ca_gazebo/test/scripts/publish.py
@@ -9,9 +9,9 @@ from ca_msgs.msg import Bumper, Cliff
 __author__ = 'Emiliano Borghi'
 
 PKG = 'ca_gazebo'
-NAME = 'plugins'
+NAME = 'publish'
 
-class PluginsTesterClass(unittest.TestCase):
+class PublisherTests(unittest.TestCase):
 
   def __init__(self, *args):
     # Init ROS and params
@@ -19,7 +19,7 @@ class PluginsTesterClass(unittest.TestCase):
     self.timeout = rospy.get_param("~timeout_s", default=10.0)
     rospy.loginfo("Timeout set to {} seconds".format(self.timeout))
     # Call TestCase class
-    super(PluginsTesterClass, self).__init__(*args)
+    super(PublisherTests, self).__init__(*args)
 
   def check(self, topic, msg_type, callback):
     self.message_triggered = False
@@ -55,4 +55,4 @@ class PluginsTesterClass(unittest.TestCase):
          msg.is_cliff_front_right or msg.is_cliff_right)
 
 if __name__ == '__main__':
-  rostest.rosrun(PKG, NAME, PluginsTesterClass, sys.argv)
+  rostest.rosrun(PKG, NAME, PublisherTests, sys.argv)

--- a/ca_gazebo/test/scripts/static.py
+++ b/ca_gazebo/test/scripts/static.py
@@ -1,0 +1,58 @@
+#!/usr/bin/env python
+import rospy
+import rostest
+import unittest
+import sys
+
+import numpy as np
+
+from sensor_msgs.msg import JointState
+
+__author__ = 'Emiliano Borghi'
+
+PKG = 'ca_gazebo'
+NAME = 'static'
+
+class StaticRobotTest(unittest.TestCase):
+
+  def __init__(self, *args):
+    # Init ROS and params
+    rospy.init_node(NAME, anonymous=True)
+    self.timeout = rospy.get_param("~timeout_s", default=10.0)
+    rospy.loginfo("Timeout set to {} seconds".format(self.timeout))
+    self.position_error = float(rospy.get_param("~position_error", default=1e-6))
+    # Call TestCase class
+    super(StaticRobotTest, self).__init__(*args)
+
+  def test_static_robot(self):
+    self.initial_position = None
+    self.final_position = None
+    sub = rospy.Subscriber('/create1/joint_states', JointState, self.joint_state_cb)
+
+    rate_hz = rospy.Rate(20)  # 20 Hz
+    timeout_t = rospy.get_time() + self.timeout
+    while (not rospy.is_shutdown()) and \
+          (rospy.get_time() <= timeout_t):
+      rate_hz.sleep()
+    # Unregister subscriber
+    sub.unregister()
+
+    # Checking that wheels have not been moved during the specified time
+    diff = np.abs(np.diff([self.final_position, self.initial_position]))
+    self.assertLessEqual(
+      diff.item(0),
+      self.position_error,
+      msg="The robot is not static. Left wheel has moved {} rad/s".format(str(diff.item(0))))
+    self.assertLessEqual(
+      diff.item(1),
+      self.position_error,
+      msg="The robot is not static. Right wheel has moved {} rad/s".format(str(diff.item(1))))
+
+  def joint_state_cb(self, msg):
+    if self.initial_position is None:
+      self.initial_position = msg.position
+    else:
+       self.final_position = msg.position
+
+if __name__ == '__main__':
+  rostest.rosrun(PKG, NAME, StaticRobotTest, sys.argv)

--- a/ca_gazebo/test/static.test
+++ b/ca_gazebo/test/static.test
@@ -1,0 +1,19 @@
+<launch>
+  <arg name="gui" default="false"/>
+
+  <include file="$(find ca_gazebo)/launch/create_empty_world.launch">
+    <arg name="gui" value="$(arg gui)"/>
+  </include>
+
+  <!-- Change real-time factor of Gazebo -->
+  <node pkg="ca_gazebo" type="set_properties" name="gazebo_physics_properties" output="screen">
+    <param name="real_time_factor" value="10"/>
+  </node>
+
+  <test test-name="static_test" name="static_test"
+        type="static.py" pkg="ca_gazebo"
+        time-limit="100.0">
+    <param name="timeout_s"        value="180.0"/>
+    <param name="position_error"   value="5e-4"/>
+  </test>
+</launch>

--- a/ca_tools/rviz/tf.rviz
+++ b/ca_tools/rviz/tf.rviz
@@ -71,6 +71,16 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
           Value: true
+        battery_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bumper_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
         caster_wheel_link:
           Alpha: 1
           Show Axes: false
@@ -197,6 +207,10 @@ Visualization Manager:
           Value: true
         create1_tf/base_link:
           Value: false
+        create1_tf/battery_link:
+          Value: false
+        create1_tf/bumper_link:
+          Value: false
         create1_tf/caster_wheel_link:
           Value: false
         create1_tf/front_left_cliff_sensor_link:
@@ -253,54 +267,59 @@ Visualization Manager:
       Show Axes: true
       Show Names: true
       Tree:
+        create1_tf/base_footprint:
+          create1_tf/base_link:
+            create1_tf/bumper_link:
+              {}
+            create1_tf/caster_wheel_link:
+              {}
+            create1_tf/front_left_cliff_sensor_link:
+              {}
+            create1_tf/front_right_cliff_sensor_link:
+              {}
+            create1_tf/imu_link:
+              {}
+            create1_tf/omni_sensor_link:
+              {}
+            create1_tf/rplidar_link:
+              create1_tf/laser_link:
+                {}
+            create1_tf/side_left_cliff_sensor_link:
+              {}
+            create1_tf/side_right_cliff_sensor_link:
+              {}
+            create1_tf/turtlebot_stack_base_link:
+              create1_tf/plate_bottom_link:
+                create1_tf/nvidia_jetson_nano_link:
+                  {}
+              create1_tf/plate_upper_link:
+                {}
+              create1_tf/pole_large_0_link:
+                {}
+              create1_tf/pole_large_1_link:
+                {}
+              create1_tf/pole_large_2_link:
+                {}
+              create1_tf/pole_large_3_link:
+                {}
+              create1_tf/pole_short_0_link:
+                {}
+              create1_tf/pole_short_1_link:
+                {}
+              create1_tf/pole_short_2_link:
+                {}
+              create1_tf/pole_short_3_link:
+                {}
+            create1_tf/wall_sensor_link:
+              {}
+          create1_tf/battery_link:
+            {}
+          create1_tf/wheel_left_link:
+            {}
+          create1_tf/wheel_right_link:
+            {}
         create1_tf/odom:
-          create1_tf/base_footprint:
-            create1_tf/base_link:
-              create1_tf/caster_wheel_link:
-                {}
-              create1_tf/front_left_cliff_sensor_link:
-                {}
-              create1_tf/front_right_cliff_sensor_link:
-                {}
-              create1_tf/imu_link:
-                {}
-              create1_tf/omni_sensor_link:
-                {}
-              create1_tf/rplidar_link:
-                create1_tf/laser_link:
-                  {}
-              create1_tf/side_left_cliff_sensor_link:
-                {}
-              create1_tf/side_right_cliff_sensor_link:
-                {}
-              create1_tf/turtlebot_stack_base_link:
-                create1_tf/plate_bottom_link:
-                  create1_tf/nvidia_jetson_nano_link:
-                    {}
-                create1_tf/plate_upper_link:
-                  {}
-                create1_tf/pole_large_0_link:
-                  {}
-                create1_tf/pole_large_1_link:
-                  {}
-                create1_tf/pole_large_2_link:
-                  {}
-                create1_tf/pole_large_3_link:
-                  {}
-                create1_tf/pole_short_0_link:
-                  {}
-                create1_tf/pole_short_1_link:
-                  {}
-                create1_tf/pole_short_2_link:
-                  {}
-                create1_tf/pole_short_3_link:
-                  {}
-              create1_tf/wall_sensor_link:
-                {}
-            create1_tf/wheel_left_link:
-              {}
-            create1_tf/wheel_right_link:
-              {}
+          {}
       Update Interval: 0
       Value: true
   Enabled: true


### PR DESCRIPTION
This PR includes the following changes:

- Add `set_properties` script for Gazebo to change the RTF of the simulation
- Add static test to don't have regressions because of wheel drifts
- Add battery to reduce drift
- Change robots' initial pose at startup