### PR TITLE
Fix global costamp inflation layer

### DIFF
--- a/ca_description/scripts/robot_spawner.py
+++ b/ca_description/scripts/robot_spawner.py
@@ -11,14 +11,15 @@ from tf.transformations import quaternion_from_euler
 class RobotSpawner(object):
 
   SPAWN_URDF_TOPIC = '/gazebo/spawn_urdf_model'
+  TIMEOUT_S = rospy.Duration(secs=10.0)
 
   def __init__(self):
     rospy.init_node('robot_spawner')
-    self.ns = rospy.get_namespace()
+    ns = rospy.get_namespace()
 
     # Get robot index
     try:
-      index = re.findall('[0-9]+', self.ns)[0]
+      index = re.findall('[0-9]+', ns)[0]
     except IndexError:
       index = 0
     i = index
@@ -36,21 +37,28 @@ class RobotSpawner(object):
 
       # Robot information from robot_description
       robot_description_param = "/create{}/robot_description".format(i)
-      if rospy.has_param(robot_description_param):
-        msg.model_xml = rospy.get_param(robot_description_param)
 
-      msg.robot_namespace = self.ns
+      # Wait for params
+      pose_param = "{}/amcl".format(ns)
+      initial_time = rospy.Time.now()
+      while RobotSpawner.TIMEOUT_S > (rospy.Time.now() - initial_time):
+        if rospy.has_param(robot_description_param) and rospy.has_param(pose_param):
+          break
+
+      msg.model_xml = rospy.get_param(robot_description_param)
+
+      msg.robot_namespace = ns
 
       # Using pose from parameter server
       msg.initial_pose = Pose()
       msg.initial_pose.position.x = rospy.get_param(
-            "{}/amcl/initial_pose_x".format(self.ns), randint(-10, 10))
+            "{}/initial_pose_x".format(pose_param), randint(-10, 10))
       msg.initial_pose.position.y = rospy.get_param(
-            "{}/amcl/initial_pose_y".format(self.ns), randint(-10, 10))
+            "{}/initial_pose_y".format(pose_param), randint(-10, 10))
       msg.initial_pose.position.z = rospy.get_param(
-            "{}/amcl/initial_pose_z".format(self.ns), 0.)
+            "{}/initial_pose_z".format(pose_param), 0.)
       yaw = rospy.get_param(
-            "{}/amcl/initial_pose_a".format(self.ns), 0.)
+            "{}/initial_pose_a".format(pose_param), 0.)
       q = quaternion_from_euler(0, 0, yaw)
       msg.initial_pose.orientation = Quaternion(q[0], q[1], q[2], q[3])
 

--- a/ca_description/scripts/robot_spawner.py
+++ b/ca_description/scripts/robot_spawner.py
@@ -12,6 +12,7 @@ class RobotSpawner(object):
 
   SPAWN_URDF_TOPIC = '/gazebo/spawn_urdf_model'
   TIMEOUT_S = rospy.Duration(secs=10.0)
+  CHECK_RATE_HZ   = 5
 
   def __init__(self):
     rospy.init_node('robot_spawner')
@@ -44,6 +45,7 @@ class RobotSpawner(object):
       while RobotSpawner.TIMEOUT_S > (rospy.Time.now() - initial_time):
         if rospy.has_param(robot_description_param) and rospy.has_param(pose_param):
           break
+        rospy.sleep(1/RobotSpawner.CHECK_RATE_HZ)
 
       msg.model_xml = rospy.get_param(robot_description_param)
 

--- a/ca_tools/launch/rviz.launch
+++ b/ca_tools/launch/rviz.launch
@@ -1,7 +1,12 @@
 <?xml version="1.0"?>
 <launch>
+  <arg name="robot_id"  default="$(optenv ID 1)"      doc="Unique identifier of the robot [1-Inf.)"/>
+  <arg name="ns"        value="create$(arg robot_id)" doc="Namespace of the robot. By default: create1"/>
+
   <arg name="config_file" default="$(optenv RVIZ_CONFIG)" doc="RViz configuration file"/>
 
   <node type="rviz" name="rviz" pkg="rviz" required="false"
-        args="-d $(find ca_tools)/rviz/$(arg config_file).rviz"/>
+        args="-d $(find ca_tools)/rviz/$(arg config_file).rviz">
+    <remap from="/move_base_simple/goal" to="/$(arg ns)/move_base_simple/goal"/>
+  </node>
 </launch>

--- a/ca_tools/rviz/navigation.rviz
+++ b/ca_tools/rviz/navigation.rviz
@@ -5,7 +5,7 @@ Panels:
     Property Tree Widget:
       Expanded: ~
       Splitter Ratio: 0.5
-    Tree Height: 772
+    Tree Height: 726
   - Class: rviz/Selection
     Name: Selection
   - Class: rviz/Tool Properties
@@ -120,29 +120,6 @@ Visualization Manager:
       Use Fixed Frame: true
       Use rainbow: true
       Value: true
-    - Alpha: 1
-      Buffer Length: 1
-      Class: rviz/Path
-      Color: 25; 255; 0
-      Enabled: true
-      Head Diameter: 0.30000001192092896
-      Head Length: 0.20000000298023224
-      Length: 0.30000001192092896
-      Line Style: Lines
-      Line Width: 0.029999999329447746
-      Name: Global Path
-      Offset:
-        X: 0
-        Y: 0
-        Z: 0
-      Pose Color: 255; 85; 255
-      Pose Style: None
-      Radius: 0.029999999329447746
-      Shaft Diameter: 0.10000000149011612
-      Shaft Length: 0.10000000149011612
-      Topic: /create1/move_base/DWAPlannerROS/global_plan
-      Unreliable: false
-      Value: true
     - Alpha: 0.699999988079071
       Class: rviz/Map
       Color Scheme: costmap
@@ -183,6 +160,16 @@ Visualization Manager:
           Show Axes: false
           Show Trail: false
         base_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        battery_link:
+          Alpha: 1
+          Show Axes: false
+          Show Trail: false
+          Value: true
+        bumper_link:
           Alpha: 1
           Show Axes: false
           Show Trail: false
@@ -343,13 +330,54 @@ Visualization Manager:
       Enabled: true
       Head Length: 0.07000000029802322
       Head Radius: 0.029999999329447746
-      Name: PoseArray
+      Name: AMCL
       Shaft Length: 0.23000000417232513
       Shaft Radius: 0.009999999776482582
       Shape: Arrow (Flat)
       Topic: /particlecloud
       Unreliable: false
       Value: true
+    - Alpha: 1
+      Buffer Length: 1
+      Class: rviz/Path
+      Color: 25; 255; 0
+      Enabled: true
+      Head Diameter: 0.30000001192092896
+      Head Length: 0.20000000298023224
+      Length: 0.30000001192092896
+      Line Style: Lines
+      Line Width: 0.029999999329447746
+      Name: Global plan
+      Offset:
+        X: 0
+        Y: 0
+        Z: 0
+      Pose Color: 255; 85; 255
+      Pose Style: None
+      Radius: 0.029999999329447746
+      Shaft Diameter: 0.10000000149011612
+      Shaft Length: 0.10000000149011612
+      Topic: /create1/move_base/NavfnROS/plan
+      Unreliable: false
+      Value: true
+    - Alpha: 1
+      Class: rviz/Polygon
+      Color: 25; 255; 0
+      Enabled: true
+      Name: Footprint
+      Topic: /create1/move_base/global_costmap/footprint
+      Unreliable: false
+      Value: true
+    - Alpha: 0.699999988079071
+      Class: rviz/Map
+      Color Scheme: map
+      Draw Behind: false
+      Enabled: false
+      Name: Global costmap
+      Topic: /create1/move_base/global_costmap/costmap
+      Unreliable: false
+      Use Timestamp: false
+      Value: false
   Enabled: true
   Global Options:
     Background Color: 48; 48; 48
@@ -377,34 +405,29 @@ Visualization Manager:
   Value: true
   Views:
     Current:
-      Class: rviz/Orbit
-      Distance: 18.01032066345215
+      Angle: 3.221593141555786
+      Class: rviz/TopDownOrtho
       Enable Stereo Rendering:
         Stereo Eye Separation: 0.05999999865889549
         Stereo Focal Distance: 1
         Swap Stereo Eyes: false
         Value: false
-      Focal Point:
-        X: 0
-        Y: 0
-        Z: 0
-      Focal Shape Fixed Size: true
-      Focal Shape Size: 0.05000000074505806
       Invert Z Axis: false
       Name: Current View
       Near Clip Distance: 0.009999999776482582
-      Pitch: 0.785398006439209
-      Target Frame: <Fixed Frame>
-      Value: Orbit (rviz)
-      Yaw: 0.785398006439209
+      Scale: 161.00779724121094
+      Target Frame: create1_tf/base_footprint
+      Value: TopDownOrtho (rviz)
+      X: -0.3720692992210388
+      Y: -1.142160415649414
     Saved: ~
 Window Geometry:
   Displays:
-    collapsed: false
-  Height: 1248
-  Hide Left Dock: false
-  Hide Right Dock: false
-  QMainWindow State: 000000ff00000000fd0000000400000000000002c1000003f2fc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b000000ab00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c0061007900730100000069000003f20000017800fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c00000261000000010000010f0000025efc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a0056006900650077007300000000280000025e0000012300fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e10000019700000003000008fb00000050fc0100000002fb0000000800540069006d00650100000000000008fb0000045300fffffffb0000000800540069006d006501000000000000045000000000000000000000062e000003f200000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
+    collapsed: true
+  Height: 1095
+  Hide Left Dock: true
+  Hide Right Dock: true
+  QMainWindow State: 000000ff00000000fd0000000400000000000002b20000039bfc0200000008fb0000001200530065006c0065006300740069006f006e00000001e10000009b0000005c00fffffffb0000001e0054006f006f006c002000500072006f007000650072007400690065007302000001ed000001df00000185000000a3fb000000120056006900650077007300200054006f006f02000001df000002110000018500000122fb000000200054006f006f006c002000500072006f0070006500720074006900650073003203000002880000011d000002210000017afb000000100044006900730070006c006100790073000000003b0000039b000000c700fffffffb0000002000730065006c0065006300740069006f006e00200062007500660066006500720200000138000000aa0000023a00000294fb00000014005700690064006500530074006500720065006f02000000e6000000d2000003ee0000030bfb0000000c004b0069006e0065006300740200000186000001060000030c0000026100000001000001d20000039bfc0200000003fb0000001e0054006f006f006c002000500072006f00700065007200740069006500730100000041000000780000000000000000fb0000000a00560069006500770073000000003b0000039b000000a000fffffffb0000001200530065006c0065006300740069006f006e010000025a000000b200000000000000000000000200000490000000a9fc0100000001fb0000000a00560069006500770073030000004e00000080000002e100000197000000030000050600000050fc0100000002fb0000000800540069006d00650100000000000005060000024400fffffffb0000000800540069006d00650100000000000004500000000000000000000005060000039b00000004000000040000000800000008fc0000000100000002000000010000000a0054006f006f006c00730100000000ffffffff0000000000000000
   Selection:
     collapsed: false
   Time:
@@ -412,7 +435,7 @@ Window Geometry:
   Tool Properties:
     collapsed: false
   Views:
-    collapsed: false
-  Width: 2299
-  X: 517
-  Y: 199
+    collapsed: true
+  Width: 1286
+  X: 717
+  Y: 27

--- a/navigation/ca_cartographer/launch/mapping_cartographer.launch
+++ b/navigation/ca_cartographer/launch/mapping_cartographer.launch
@@ -10,8 +10,7 @@
     <node name="cartographer_node" pkg="cartographer_ros"
         type="cartographer_node" args="
             -configuration_directory $(find ca_cartographer)/config
-            -configuration_basename mapping_2d.lua"
-        output="screen">
+            -configuration_basename mapping_2d.lua">
       <!-- ID needs to be set through environment variable to allow lua script to read it -->
       <env name="ID" value="$(arg robot_id)" />
       <remap from="scan" to="$(arg ns)/$(arg laser)/scan" />

--- a/navigation/ca_move_base/config/costmap_common_params.yaml
+++ b/navigation/ca_move_base/config/costmap_common_params.yaml
@@ -1,13 +1,19 @@
 transform_tolerance: 0.25
-
 robot_radius: 0.18
+track_unknown_space: true   # true needed for disabling global path planning through unknown space
+raytrace_range: 3.0
 
 inflation_layer:
-  inflation_radius: 0.2
+  enabled: true
+  inflation_radius: 0.2     # max. distance from an obstacle at which costs are incurred for planning paths.
+  cost_scaling_factor:  10  # exponential rate at which the obstacle cost drops off (default: 10)
+  inflate_unknown: true
 
 obstacle_layer:
+  enabled: true
   obstacle_range: 2.5
   raytrace_range: 5.5
+  combination_method: 1
   observation_sources: bump scan
   bump: {
     data_type: PointCloud2,
@@ -26,3 +32,8 @@ obstacle_layer:
       min_obstacle_height: -0.1,
       max_obstacle_height: 6
   }
+
+static_layer:
+  enabled: true
+  map_topic: /map
+  subscribe_to_updates: true

--- a/navigation/ca_move_base/config/costmap_common_params.yaml
+++ b/navigation/ca_move_base/config/costmap_common_params.yaml
@@ -1,12 +1,13 @@
 transform_tolerance: 0.25
-robot_radius: 0.18
+robot_radius: 0.095
 track_unknown_space: true   # true needed for disabling global path planning through unknown space
 raytrace_range: 3.0
+footprint_padding: 0.0
 
 inflation_layer:
   enabled: true
-  inflation_radius: 0.2     # max. distance from an obstacle at which costs are incurred for planning paths.
-  cost_scaling_factor:  10  # exponential rate at which the obstacle cost drops off (default: 10)
+  inflation_radius: 0.5     # max. distance from an obstacle at which costs are incurred for planning paths.
+  cost_scaling_factor:  12  # exponential rate at which the obstacle cost drops off (default: 10)
   inflate_unknown: true
 
 obstacle_layer:

--- a/navigation/ca_move_base/config/dwa_local_planner_params.yaml
+++ b/navigation/ca_move_base/config/dwa_local_planner_params.yaml
@@ -28,7 +28,7 @@ DWAPlannerROS:
   theta_stopped_vel: 0.4
 
   acc_lim_x: 0.8
-  acc_lim_theta: 2.0
+  acc_lim_theta: 5.0
   acc_lim_y: 0.0      # diff drive robot
 
 # Goal Tolerance Parameters
@@ -37,9 +37,9 @@ DWAPlannerROS:
   # latch_xy_goal_tolerance: false
 
 # Forward Simulation Parameters
-  sim_time: 1.0       # 1.7
-  vx_samples: 6       # 3
-  vy_samples: 1       # diff drive robot, there is only one sample
+  sim_time: 2.0       # 1.7
+  vx_samples: 10       # 3
+  vy_samples: 10       # diff drive robot, there is only one sample
   vtheta_samples: 20  # 20
 
 # Trajectory Scoring Parameters

--- a/navigation/ca_move_base/config/dwa_local_planner_params.yaml
+++ b/navigation/ca_move_base/config/dwa_local_planner_params.yaml
@@ -55,8 +55,8 @@ DWAPlannerROS:
   oscillation_reset_dist: 0.05  # 0.05   - how far to travel before resetting oscillation flags
 
 # Debugging
-  publish_traj_pc : true
-  publish_cost_grid_pc: true
+  publish_cost_grid: true
 
-# Differential-drive robot configuration - necessary?
-  holonomic_robot: false
+# Defines whether or not to eat up the plan as the robot moves along the path.
+# If set to true, points will fall off the end of the plan once the robot moves 1 meter past them.
+  prune_plan: true

--- a/navigation/ca_move_base/config/global_costmap_params.yaml
+++ b/navigation/ca_move_base/config/global_costmap_params.yaml
@@ -1,19 +1,18 @@
 global_costmap:
 
-  plugins:
-    - {name: static_layer, type: "costmap_2d::StaticLayer" }
-    - {name: inflation_layer,  type: "costmap_2d::InflationLayer" }
-
-  update_frequency: 5.0
-  publish_frequency: 1.0
+  # Rate parameters
+  update_frequency: 1.0
+  publish_frequency: 0.5
 
   publish_voxel_map: true
 
+  # Map management parameters
   width: 30.0
   height: 30.0
   resolution: 0.05
-  
-  origin_x: 0.0
-  origin_y: 0.0
-  
-  inflation_radius: 0.26
+
+  plugins:
+    # Order matters!
+    - {name: static_layer,    type: "costmap_2d::StaticLayer" }
+    - {name: obstacle_layer,  type: "costmap_2d::VoxelLayer"}
+    - {name: inflation_layer, type: "costmap_2d::InflationLayer" }

--- a/navigation/ca_move_base/config/global_costmap_params.yaml
+++ b/navigation/ca_move_base/config/global_costmap_params.yaml
@@ -9,10 +9,10 @@ global_costmap:
   # Map management parameters
   width: 30.0
   height: 30.0
-  resolution: 0.05
+  resolution: 0.01
 
   plugins:
     # Order matters!
     - {name: static_layer,    type: "costmap_2d::StaticLayer" }
-    - {name: obstacle_layer,  type: "costmap_2d::VoxelLayer"}
+    - {name: obstacle_layer,  type: "costmap_2d::ObstacleLayer"}
     - {name: inflation_layer, type: "costmap_2d::InflationLayer" }

--- a/navigation/ca_move_base/config/local_costmap_params.yaml
+++ b/navigation/ca_move_base/config/local_costmap_params.yaml
@@ -8,7 +8,7 @@ local_costmap:
   rolling_window: true
   width: 5.0
   height: 5.0
-  resolution: 0.025
+  resolution: 0.01
 
   plugins:
     # Order matters!

--- a/navigation/ca_move_base/config/local_costmap_params.yaml
+++ b/navigation/ca_move_base/config/local_costmap_params.yaml
@@ -1,13 +1,16 @@
 local_costmap:
 
-  plugins:
-    - {name: obstacle_layer,  type: "costmap_2d::ObstacleLayer" }
-    - {name: inflation_layer,  type: "costmap_2d::InflationLayer" }
-
-  rolling_window: true
+  # Rate parameters
   publish_frequency: 2.0
   update_frequency: 5.0
 
-  width: 2.5
-  height: 2.5
+  # Map management parameters
+  rolling_window: true
+  width: 5.0
+  height: 5.0
   resolution: 0.025
+
+  plugins:
+    # Order matters!
+    - {name: obstacle_layer,  type: "costmap_2d::ObstacleLayer" }
+    - {name: inflation_layer, type: "costmap_2d::InflationLayer" }

--- a/navigation/ca_move_base/config/move_base_params.yaml
+++ b/navigation/ca_move_base/config/move_base_params.yaml
@@ -10,16 +10,16 @@ shutdown_costmaps: false
 
 # The rate in Hz at which to run the control loop and send velocity
 # commands to the base.
-controller_frequency: 5.0
+controller_frequency: 10.0
 # How long the controller will wait in seconds without receiving a
 # valid control before space-clearing operations are performed.
-controller_patience: 3.0
+controller_patience: 15.0
 
 # The rate in Hz at which to run the global planning loop. If the
 # frequency is set to 0.0, the global planner will only run when a new
 # goal is received or the local planner reports that its path is
 # blocked.
-planner_frequency: 1.0
+planner_frequency: 5.0
 # How long the planner will wait in seconds in an attempt to find a
 # valid plan before space-clearing operations are performed.
 planner_patience: 5.0
@@ -32,3 +32,12 @@ oscillation_timeout: 10.0
 # oscillating. Moving this far resets the timer counting up to the
 # ~oscillation_timeout
 oscillation_distance: 0.2
+
+recovery_behavior_enabled: true
+clearing_rotation_allowed: true
+
+recovery_behaviors:  [
+  { name: conservative_reset, type: clear_costmap_recovery/ClearCostmapRecovery },
+  { name: rotate_recovery,    type: rotate_recovery/RotateRecovery },
+  { name: aggressive_reset,   type: clear_costmap_recovery/ClearCostmapRecovery }
+]

--- a/navigation/ca_move_base/config/navfn_global_planner_params.yaml
+++ b/navigation/ca_move_base/config/navfn_global_planner_params.yaml
@@ -4,15 +4,20 @@
 # specified in the nav_core package.
 #
 # http://wiki.ros.org/nav_core#BaseGlobalPlanner
-#alternatives: global_planner/GlobalPlanner, carrot_planner/CarrotPlanner
 base_global_planner: "navfn/NavfnROS"
 
 NavfnROS:
-  visualize_potential: false    #Publish potential for rviz as pointcloud2, not really helpful, default false
-  allow_unknown: false          #Specifies whether or not to allow navfn to create plans that traverse unknown space, default true
-                                #Needs to have track_unknown_space: true in the obstacle / voxel layer (in costmap_commons_param) to work
-  planner_window_x: 0.0         #Specifies the x size of an optional window to restrict the planner to, default 0.0
-  planner_window_y: 0.0         #Specifies the y size of an optional window to restrict the planner to, default 0.0
+  # Publish potential for rviz as pointcloud2, not really helpful, default false
+  visualize_potential: false
+  # Specifies whether or not to allow navfn to create plans that traverse unknown space, default true
+  # Needs to have track_unknown_space: true in the obstacle / voxel layer (in costmap_commons_param) to work
+  allow_unknown: true
 
-  default_tolerance: 0.0        #If the goal is in an obstacle, the planer will plan to the nearest point in the radius of default_tolerance, default 0.0
-                                #The area is always searched, so could be slow for big values
+  # Specifies the x size of an optional window to restrict the planner to, default 0.0
+  planner_window_x: 0.0
+  # Specifies the y size of an optional window to restrict the planner to, default 0.0
+  planner_window_y: 0.0
+
+  # If the goal is in an obstacle, the planer will plan to the nearest point in the radius of default_tolerance, default 0.0
+  # The area is always searched, so could be slow for big values
+  default_tolerance: 0.0

--- a/navigation/ca_move_base/config/trajectory_rollout_local_planner_params.yaml
+++ b/navigation/ca_move_base/config/trajectory_rollout_local_planner_params.yaml
@@ -1,0 +1,33 @@
+base_local_planner: "base_local_planner/TrajectoryPlannerROS"
+
+TrajectoryPlannerROS:
+
+  acc_lim_x: 0.8
+  acc_lim_y: 0.0
+  acc_lim_theta: 2.0
+
+  max_vel_x: 0.3
+  min_vel_x: 0.0
+  max_vel_trans: 0.25
+  min_vel_trans: 0.1
+
+  max_vel_theta: 1.5
+  min_vel_theta: -1.5
+  min_in_place_vel_theta: 0.3
+  escape_vel: -0.4
+
+  holonomic_robot: false
+  y_vels: []
+  xy_goal_tolerance: 0.15
+  yaw_goal_tolerance: 0.3
+  latch_xy_goal_tolerance: true
+
+  sim_time: 1.0
+  sim_granularity: 0.025
+  angular_sim_granularity: 0.025
+  vx_samples: 6
+  vtheta_samples: 20
+  controller_frequency: 20
+
+  public_cost_grid_pc: true
+  meter_scoring: true

--- a/navigation/ca_move_base/launch/amcl.launch
+++ b/navigation/ca_move_base/launch/amcl.launch
@@ -14,7 +14,7 @@
     <remap from="scan" to="$(arg laser)/scan"/>
 
     <param name="odom_frame_id" value="$(arg tf_prefix)/odom"/>
-    <param name="base_frame_id" value="$(arg tf_prefix)/base_link"/>
+    <param name="base_frame_id" value="$(arg tf_prefix)/base_footprint"/>
     <param name="global_frame_id" value="map"/>
   </node>
 

--- a/navigation/ca_move_base/launch/move_base.launch
+++ b/navigation/ca_move_base/launch/move_base.launch
@@ -21,22 +21,26 @@
 
     <!-- We want a single map for multi-robots -->
     <remap from="map" to="/map"/>
-    <remap from="/laser/scan" to="/$(arg ns)/$(arg laser)/scan"/>
-    <remap from="/mobile_base/sensors/bumper_pointcloud"
-           to="mobile_base/sensors/bumper_pointcloud"/>
+    <remap from="scan" to="/$(arg ns)/$(arg laser)/scan"/>
+    <!-- <remap from="/mobile_base/sensors/bumper_pointcloud"
+           to="mobile_base/sensors/bumper_pointcloud"/> -->
 
     <remap from="odom" to="/$(arg ns)/odom"/>
     <remap from="cmd_vel" to="/$(arg ns)/cmd_vel"/>
 
     <!-- Remap frames for specific robots -->
-    <param name="local_costmap/robot_base_frame" value="$(arg tf_prefix)/base_link"/>
-    <param name="global_costmap/robot_base_frame" value="$(arg tf_prefix)/base_link"/>
+    <param name="local_costmap/robot_base_frame" value="$(arg tf_prefix)/base_footprint"/>
     <param name="local_costmap/global_frame" value="$(arg tf_prefix)/odom"/>
-    <param name="global_costmap/global_frame" value="map"/>
     <param name="local_costmap/obstacle_layer/scan/sensor_frame" value="$(arg tf_prefix)/$(arg laser)_link"/>
+    <param name="local_costmap/obstacle_layer/scan/topic"  value="/$(arg ns)/$(arg laser)/scan"/>
 
-    <param name="global_costmap/obstacle_layer/scan/topic" value="$(arg laser)/scan"/>
-    <param name="local_costmap/obstacle_layer/scan/topic"  value="$(arg laser)/scan"/>
+    <param name="global_costmap/robot_base_frame" value="$(arg tf_prefix)/base_footprint"/>
+    <param name="global_costmap/global_frame" value="map"/>
+    <param name="global_costmap/static_layer/map_topic"  value="/map"/>
+    <param name="global_costmap/obstacle_layer/scan/sensor_frame" value="$(arg tf_prefix)/$(arg laser)_link"/>
+    <param name="global_costmap/obstacle_layer/scan/topic" value="/$(arg ns)/$(arg laser)/scan"/>
+
+    <param name="DWAPlannerROS/global_frame_id"  value="$(arg tf_prefix)/odom"/>
   </node>
 
 </launch>


### PR DESCRIPTION
This PR fixes the global costmap inflation layer to detect new obstacles in the map.
It also adds a new local planner (`trajectory_rollout`).

**Instructions:**

```bash
LOCALIZATION=amcl RVIZ_CONFIG=navigation roslaunch ca_gazebo create_house.launch
```

**Notes:**

I started seeing these messages but I don't know where they came from.

```
[ WARN] [1588730864.746267022, 4.260000000]: local_costmap: Pre-Hydro parameter "static_map" unused since "plugins" is provided
[ WARN] [1588730864.746892824, 4.261000000]: local_costmap: Pre-Hydro parameter "map_type" unused since "plugins" is provided
```

At the beginning I'm seeing a lot of this:

```
DWA planner failed to produce path.
```

![Screenshot from 2020-05-05 23-10-38](https://user-images.githubusercontent.com/3400230/81132705-b5825180-8f25-11ea-9f99-86e5d517fd07.png)

I suspect that `move_base` can be tweaked a bit more too.