### PR TITLE
Add origin calibrated for 3D sensors

### DIFF
--- a/ca_description/urdf/sensors/lasers/astra.xacro
+++ b/ca_description/urdf/sensors/lasers/astra.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
+<xacro:include filename="$(find ca_description)/urdf/sensors/lasers/calibration.xacro"/>
 <xacro:include filename="$(find ca_description)/urdf/sensors/lasers/sim_3d_sensor.xacro"/>
 
 <!-- Orbbec Astra RGBD Camera -->
@@ -14,8 +15,6 @@
 <xacro:property name="link_rgb_optical"   value="${name}_rgb_optical_frame"/>
 <xacro:property name="link_depth"         value="${name}_depth_frame"/>
 <xacro:property name="link_depth_optical" value="${name}_depth_optical_frame"/>
-
-<xacro:property name="optical_rotation" value="${-pi/2} 0 ${-pi/2}"/>
 
 <joint name="${name}_joint" type="fixed">
   <origin xyz="${laser_origin}"/>
@@ -40,7 +39,7 @@
 <link name="${link_rgb}"/>
 
 <joint name="${name}_rgb_optical_joint" type="fixed">
-  <origin rpy="${optical_rotation}"/>
+  <xacro:origin_calibrated camera="${name}" type="rgb"/>
   <parent link="${link_rgb}"/>
   <child link="${link_rgb_optical}"/>
 </joint>
@@ -54,7 +53,7 @@
 <link name="${link_depth}"/>
 
   <joint name="${name}_depth_optical_joint" type="fixed">
-  <origin rpy="${optical_rotation}"/>
+  <xacro:origin_calibrated camera="${name}" type="depth"/>
   <parent link="${link_depth}"/>
   <child link="${link_depth_optical}"/>
 </joint>

--- a/ca_description/urdf/sensors/lasers/calibration.xacro
+++ b/ca_description/urdf/sensors/lasers/calibration.xacro
@@ -1,0 +1,23 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+<!-- Load YAML that stores calibration poses -->
+<xacro:property name="yaml_file" value="$(find ca_description)/urdf/sensors/lasers/calibration.yaml"/>
+<xacro:property name="calib"     value="${load_yaml(yaml_file)}"/>
+
+<xacro:macro name="origin_calibrated" params="camera type">
+  <!-- Get calibrated pose from dictionary -->
+  <xacro:property name="pose" value="${calib[camera][type]}"/>
+  <!-- Position: xyz -->
+  <xacro:property name="x" value="${pose['xyz'][0]}"/>
+  <xacro:property name="y" value="${pose['xyz'][1]}"/>
+  <xacro:property name="z" value="${pose['xyz'][2]}"/>
+  <!-- Orientation: RPY -->
+  <xacro:property name="R" value="${-pi/2 + pose['rpy'][0]}"/>
+  <xacro:property name="P" value="${pose['rpy'][1]}"/>
+  <xacro:property name="Y" value="${-pi/2 + pose['rpy'][2]}"/>
+  <!-- Create origin block -->
+  <origin xyz="${x} ${y} ${z}" rpy="${R} ${P} ${Y}"/>
+</xacro:macro>
+
+</robot>

--- a/ca_description/urdf/sensors/lasers/calibration.yaml
+++ b/ca_description/urdf/sensors/lasers/calibration.yaml
@@ -1,0 +1,31 @@
+astra:
+  rgb:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+  depth:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+
+kinect:
+  rgb:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+  depth:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+
+r200:
+  rgb:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+  depth:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+
+xtion_pro:
+  rgb:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+  depth:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]

--- a/ca_description/urdf/sensors/lasers/kinect.xacro
+++ b/ca_description/urdf/sensors/lasers/kinect.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
+<xacro:include filename="$(find ca_description)/urdf/sensors/lasers/calibration.xacro"/>
 <xacro:include filename="$(find ca_description)/urdf/sensors/lasers/sim_3d_sensor.xacro"/>
 
 <xacro:property name="name" value="kinect"/>
@@ -14,7 +15,6 @@
 <xacro:property name="link_depth_optical" value="${name}_depth_optical_frame"/>
 
 <xacro:property name="kinect_cam_py"    value="-0.0125"/>
-<xacro:property name="optical_rotation" value="${-pi/2} 0 ${-pi/2}"/>
 
 <joint name="camera_rgb_joint" type="fixed">
   <origin xyz="${laser_origin}"/>
@@ -24,7 +24,7 @@
 <link name="${link_rgb}"/>
 
 <joint name="${name}_rgb_optical_joint" type="fixed">
-  <origin rpy="${optical_rotation}" />
+  <xacro:origin_calibrated camera="${name}" type="rgb"/>
   <parent link="${link_rgb}" />
   <child link="${link_rgb_optical}" />
 </joint>
@@ -52,7 +52,7 @@
 <link name="${link_depth}"/>
 
 <joint name="${name}_depth_optical_joint" type="fixed">
-  <origin rpy="${optical_rotation}" />
+  <xacro:origin_calibrated camera="${name}" type="depth"/>
   <parent link="${link_depth}" />
   <child link="${link_depth_optical}"/>
 </joint>

--- a/ca_description/urdf/sensors/lasers/r200.xacro
+++ b/ca_description/urdf/sensors/lasers/r200.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://www.ros.org/wiki/xacro">
 
+<xacro:include filename="$(find ca_description)/urdf/sensors/lasers/calibration.xacro"/>
 <xacro:include filename="$(find ca_description)/urdf/sensors/lasers/sim_3d_sensor.xacro"/>
 
 <xacro:property name="name" value="r200"/>
@@ -13,9 +14,8 @@
 <xacro:property name="link_depth"         value="${name}_depth_frame"/>
 <xacro:property name="link_depth_optical" value="${name}_depth_optical_frame"/>
 
-<xacro:property name="rgb_offset"       value="-0.039895"/>
-<xacro:property name="depth_offset"     value="-0.045395"/>
-<xacro:property name="optical_rotation" value="${-pi/2} 0 ${-pi/2}"/>
+<xacro:property name="rgb_offset"   value="-0.039895"/>
+<xacro:property name="depth_offset" value="-0.045395"/>
 
 <joint name="${name}_joint" type="fixed">
   <origin xyz="${laser_origin}"/>
@@ -32,30 +32,30 @@
 </link>
 
 <joint name="${name}_rgb_joint" type="fixed">
-    <origin xyz="0 ${rgb_offset} 0"/>
-    <parent link="${link_name}"/>
-    <child link="${link_rgb}" />
+  <origin xyz="0 ${rgb_offset} 0"/>
+  <parent link="${link_name}"/>
+  <child link="${link_rgb}" />
 </joint>
 <link name="${link_rgb}"/>
 
 <joint name="${name}_rgb_optical_joint" type="fixed">
-    <origin rpy="${optical_rotation}"/>
-    <parent link="${link_rgb}"/>
-    <child link="${link_rgb_optical}"/>
+  <xacro:origin_calibrated camera="${name}" type="rgb"/>
+  <parent link="${link_rgb}"/>
+  <child link="${link_rgb_optical}"/>
 </joint>
 <link name="${link_rgb_optical}"/>
 
 <joint name="${name}_depth_joint" type="fixed">
-    <origin xyz="0 ${depth_offset} 0"/>
-    <parent link="${link_name}"/>
-    <child link="${link_depth}"/>
+  <origin xyz="0 ${depth_offset} 0"/>
+  <parent link="${link_name}"/>
+  <child link="${link_depth}"/>
 </joint>
 <link name="${link_depth}"/>
 
 <joint name="${name}_depth_optical_joint" type="fixed">
-    <origin rpy="${optical_rotation}"/>
-    <parent link="${link_depth}"/>
-    <child link="${link_depth_optical}"/>
+  <xacro:origin_calibrated camera="${name}" type="depth"/>
+  <parent link="${link_depth}"/>
+  <child link="${link_depth_optical}"/>
 </joint>
 <link name="${link_depth_optical}"/>
 

--- a/ca_description/urdf/sensors/lasers/xtion_pro.xacro
+++ b/ca_description/urdf/sensors/lasers/xtion_pro.xacro
@@ -1,6 +1,7 @@
 <?xml version="1.0"?>
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
+<xacro:include filename="$(find ca_description)/urdf/sensors/lasers/calibration.xacro"/>
 <xacro:include filename="$(find ca_description)/urdf/sensors/lasers/sim_3d_sensor.xacro"/>
 
 <!-- Orbbec Astra RGBD Camera -->
@@ -18,10 +19,9 @@
 
 <!-- This relates the IR sensor to the Xtion base link -->
 <!-- 4.8 cm because sensors are offset to right, from center -->
-<xacro:property name="ir_offset"        value="0.048"/>
+<xacro:property name="ir_offset"  value="0.048"/>
 <!-- The measured distance from RGB lens back to IR lens, approx 2.5cm -->
-<xacro:property name="rgb_offset"       value="-0.025"/>
-<xacro:property name="optical_rotation" value="${-pi/2} 0 ${-pi/2}"/>
+<xacro:property name="rgb_offset" value="-0.025"/>
 
 <joint name="${name}_joint" type="fixed">
   <origin xyz="${laser_origin}"/>
@@ -47,7 +47,7 @@
 
 <!-- Xtion RGB sensor frame -->
 <joint name="${name}_rgb_optical_joint" type="fixed">
-  <origin rpy="${optical_rotation}" />
+  <xacro:origin_calibrated camera="${name}" type="rgb"/>
   <parent link="${link_rgb}" />
   <child link="${link_rgb_optical}" />
 </joint>
@@ -63,7 +63,7 @@
 
 <!-- Xtion IR sensor frame -->
 <joint name="${name}_depth_optical_joint" type="fixed">
-  <origin rpy="${optical_rotation}" />
+  <xacro:origin_calibrated camera="${name}" type="depth"/>
   <parent link="${link_depth}" />
   <child link="${link_depth_optical}" />
 </joint>


### PR DESCRIPTION
This PR adds the possibility to administrate calibration in a single file: `calibration.yaml`.
This is then loaded into the Xacro description.