### PR TITLE
Add teb local planner

### DIFF
--- a/docker/create_ros_melodic_gazebo9/packages.txt
+++ b/docker/create_ros_melodic_gazebo9/packages.txt
@@ -40,6 +40,7 @@ ros-*-rqt-common-plugins
 ros-*-rqt-robot-plugins
 ros-*-slam-gmapping
 ros-*-smach-viewer
+ros-*-teb-local-planner
 ros-*-transmission-interface
 ros-*-xacro
 ros-*-yocs-controllers

--- a/navigation/ca_move_base/config/teb_local_planner_params.yaml
+++ b/navigation/ca_move_base/config/teb_local_planner_params.yaml
@@ -1,0 +1,114 @@
+base_local_planner: "teb_local_planner/TebLocalPlannerROS"
+
+# Reference: http://wiki.ros.org/teb_local_planner
+TebLocalPlannerROS:
+
+ odom_topic: odom
+
+ # Trajectory
+
+ teb_autosize: True
+ dt_ref: 0.3
+ dt_hysteresis: 0.1
+ max_samples: 500
+ global_plan_overwrite_orientation: True
+ allow_init_with_backwards_motion: False
+ max_global_plan_lookahead_dist: 3.0
+ global_plan_viapoint_sep: -1
+ global_plan_prune_distance: 1
+ exact_arc_length: False
+ feasibility_check_no_poses: 5
+ publish_feedback: True
+
+ # Robot
+
+ max_vel_x: 0.4
+ max_vel_x_backwards: 0.2 # Set a little lower than forward vel, since it doesn't have bumpers in the back
+ max_vel_y: 0.0
+ max_vel_theta: 1.
+ acc_lim_x: 0.5
+ acc_lim_theta: 1.
+ min_turning_radius: 0.0 # diff-drive robot (can turn on place!)
+
+ footprint_model:
+   type: "circular"
+   radius: 0.185 # footprint radius
+
+ # GoalTolerance
+
+ xy_goal_tolerance: 0.2
+ yaw_goal_tolerance: 0.1
+ free_goal_vel: False
+ complete_global_plan: True
+
+ # Obstacles
+
+ min_obstacle_dist: 0.05
+ inflation_dist: 1.0
+ include_costmap_obstacles: True
+ costmap_obstacles_behind_robot_dist: 1.5
+ obstacle_poses_affected: 15
+
+ dynamic_obstacle_inflation_dist: 0.6
+ include_dynamic_obstacles: True
+
+ costmap_converter_plugin: ""
+ costmap_converter_spin_thread: True
+ costmap_converter_rate: 5
+
+ # Optimization
+
+ no_inner_iterations: 5
+ no_outer_iterations: 4
+ optimization_activate: True
+ optimization_verbose: False
+ penalty_epsilon: 0.1
+ obstacle_cost_exponent: 4
+ weight_max_vel_x: 2
+ weight_max_vel_theta: 1
+ weight_acc_lim_x: 1
+ weight_acc_lim_theta: 1
+ weight_kinematics_nh: 1000
+ weight_kinematics_forward_drive: 1
+ weight_kinematics_turning_radius: 1
+ weight_optimaltime: 1 # must be > 0
+ weight_shortest_path: 0
+ weight_obstacle: 100
+ weight_inflation: 0.2
+ weight_dynamic_obstacle: 0
+ weight_dynamic_obstacle_inflation: 0.2
+ weight_viapoint: 1
+ weight_adapt_factor: 2
+
+ # Homotopy Class Planner
+
+ enable_homotopy_class_planning: True
+ enable_multithreading: True
+ max_number_classes: 4
+ selection_cost_hysteresis: 1.0
+ selection_prefer_initial_plan: 0.9
+ selection_obst_cost_scale: 100.0
+ selection_alternative_time_cost: False
+
+ roadmap_graph_no_samples: 15
+ roadmap_graph_area_width: 5
+ roadmap_graph_area_length_scale: 1.0
+ h_signature_prescaler: 0.5
+ h_signature_threshold: 0.1
+ obstacle_heading_threshold: 0.45
+ switching_blocking_period: 0.0
+ viapoints_all_candidates: True
+ delete_detours_backwards: True
+ max_ratio_detours_duration_best_duration: 3.0
+ visualize_hc_graph: False
+ visualize_with_time_as_z_axis_scale: False
+
+# Recovery
+
+ shrink_horizon_backup: True
+ shrink_horizon_min_duration: 10
+ oscillation_recovery: True
+ oscillation_v_eps: 0.1
+ oscillation_omega_eps: 0.1
+ oscillation_recovery_min_duration: 10
+ oscillation_filter_duration: 10

--- a/navigation/ca_move_base/launch/move_base.launch
+++ b/navigation/ca_move_base/launch/move_base.launch
@@ -6,7 +6,7 @@
   <arg name="laser" value="$(optenv LASER rplidar)" doc="Laser for mapping the environment"/>
 
   <arg name="global_planner" value="$(optenv GLOBAL_PLANNER navfn)"/>
-  <arg name="local_planner"  value="$(optenv LOCAL_PLANNER dwa)"/>
+  <arg name="local_planner"  value="$(optenv LOCAL_PLANNER teb)"/>
 
   <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
     <rosparam file="$(find ca_move_base)/config/costmap_common_params.yaml" command="load" ns="global_costmap" />

--- a/navigation/ca_move_base/package.xml
+++ b/navigation/ca_move_base/package.xml
@@ -34,6 +34,7 @@
   <exec_depend>move_base_msgs</exec_depend>
   <exec_depend>octomap_server</exec_depend>
   <exec_depend>roscpp</exec_depend>
+  <exec_depend>teb_local_planner</exec_depend>
   <exec_depend>tf</exec_depend>
 
 </package>


### PR DESCRIPTION
Adds teb local planner, a planner that finds the path that will take the least to be executed.
This means, going backwards, turning while moving, etc.
Quick showcase:
![teb planner](https://user-images.githubusercontent.com/53626539/82162270-91096c00-9879-11ea-80ad-a62d0ece831a.gif)

Setting LOCAL_PLANNER=teb env variable will enable the planner.

The gif was recorded with:
`LOCAL_PLANNER=teb RVIZ_CONFIG=navigation LOCALIZATION=amcl roslaunch ca_gazebo create_house.launch`