### PR TITLE
Add more stricter builds adding CMake flags

### DIFF
--- a/ca_gazebo/CMakeLists.txt
+++ b/ca_gazebo/CMakeLists.txt
@@ -5,6 +5,10 @@ project(ca_gazebo)
 
 add_compile_options(-std=c++11)
 
+## By adding -Wall and -Werror, the compiler does not ignore warnings anymore,
+## enforcing cleaner code.
+add_definitions(-Wall -Werror)
+
 find_package(gazebo 9 REQUIRED)
 
 find_package(catkin REQUIRED

--- a/ca_gazebo/src/servicesim/FollowActorPlugin.cc
+++ b/ca_gazebo/src/servicesim/FollowActorPlugin.cc
@@ -397,7 +397,7 @@ bool FollowActorPlugin::OnFollow(const ignition::msgs::StringMsg &_req,
     ignition::msgs::Boolean &_res)
 {
   _res.set_data(false);
-  
+
   // Get target model
   auto targetName = _req.data();
 
@@ -464,4 +464,5 @@ bool FollowActorPlugin::OnDriftRosService(
 {
   _res.drift = true;
   this->dataPtr->driftFlag = true;
+  return true;
 }


### PR DESCRIPTION
This WIP PR adds some CMake flags to make build fail because of warnings.

**TODO:**

- [x] Update the rest of the packages (besides `ca_gazebo`)
- [x] Update the rest of the packages that are outside create_autonomy (including libcreate)