### PR TITLE
Mapping changes

### DIFF
--- a/ca_tools/rviz/cartographer.rviz
+++ b/ca_tools/rviz/cartographer.rviz
@@ -317,7 +317,7 @@ Visualization Manager:
       Name: Current View
       Near Clip Distance: 0.009999999776482582
       Scale: 127.88433074951172
-      Target Frame: <Fixed Frame>
+      Target Frame: /create1_tf/base_footprint
       Value: TopDownOrtho (rviz)
       X: 0
       Y: 0

--- a/navigation/ca_cartographer/config/localization_2d.lua
+++ b/navigation/ca_cartographer/config/localization_2d.lua
@@ -7,7 +7,7 @@ options = {
   map_frame = "map",
   tracking_frame = "create" ..                    -- Frame id to track from map
                    os.getenv("ID") ..
-                   "_tf/imu_link",
+                   "_tf/base_footprint",
   published_frame = "create" ..                   -- Odom frame to publish if `provide_odom_frame = true`. Even though
                     os.getenv("ID") ..            -- are not used, all the options' parameter keys are mandatory
                     "_tf/odom",

--- a/navigation/ca_cartographer/config/mapping_2d.lua
+++ b/navigation/ca_cartographer/config/mapping_2d.lua
@@ -7,7 +7,7 @@ options = {
   map_frame = "map",
   tracking_frame = "create" ..                    -- Frame id to track from map
                    os.getenv("ID") ..
-                   "_tf/imu_link",
+                   "_tf/base_footprint",
   published_frame = "create" ..                   -- Odom frame to publish if `provide_odom_frame = true`. Even though
                     os.getenv("ID") ..            -- are not used, all the options' parameter keys are mandatory
                     "_tf/odom",

--- a/navigation/ca_move_base/config/local_costmap_params.yaml
+++ b/navigation/ca_move_base/config/local_costmap_params.yaml
@@ -6,8 +6,8 @@ local_costmap:
 
   # Map management parameters
   rolling_window: true
-  width: 5.0
-  height: 5.0
+  width: 3.0
+  height: 3.0
   resolution: 0.01
 
   plugins:


### PR DESCRIPTION
This PR includes the following changes:

- Attach RViz camera to robot for `cartographer.rviz`
- Use base_footprint frame as reference for cartographer instead of IMU
- Decrease local costmap size to delete warning rates during navigation

I'm still seeing this error with `cartographer` and I couldn't find a regression during the last month:

```
Extrapolation Error: Lookup would require extrapolation into the future.  Requested time 16.453000000 but the latest data is at time 16.428000000, when looking up transform from frame [create1_tf/odom] to frame [map]

Global Frame: create1_tf/odom Plan Frame size 139: map

Could not transform the global plan to the frame of the controller
```