### PR TITLE
Add Kobuki plugin

### DIFF
--- a/ca_description/urdf/create_base_gazebo.xacro
+++ b/ca_description/urdf/create_base_gazebo.xacro
@@ -4,7 +4,18 @@
 
     <gazebo>
       <!-- Diff-drive controller -->
-      <plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
+      <plugin name="kobuki_controller" filename="libgazebo_ros_kobuki.so">
+	      <publish_tf>1</publish_tf>
+	      <left_wheel_joint_name>wheel_left_joint</left_wheel_joint_name>
+	      <right_wheel_joint_name>wheel_right_joint</right_wheel_joint_name>
+	      <wheel_separation>${wheel_separation}</wheel_separation>
+	      <wheel_diameter>${wheel_radius * 2}</wheel_diameter>
+	      <torque>1.0</torque>
+	      <velocity_command_timeout>0.6</velocity_command_timeout>
+        <rosDebugLevel>Debug</rosDebugLevel>
+	    </plugin>
+
+      <!-- <plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
         <alwaysOn>true</alwaysOn>
         <rosDebugLevel>na</rosDebugLevel>
         <updateRate>30</updateRate>
@@ -23,7 +34,7 @@
         <publishWheelJointState>true</publishWheelJointState>
         <odometrySource>world</odometrySource>
         <publishTf>true</publishTf>
-      </plugin>
+      </plugin> -->
 
       <!-- Ground truth -->
       <plugin name="p3d_base_controller" filename="libgazebo_ros_p3d.so">

--- a/ca_tools/launch/keyboard_teleop.launch
+++ b/ca_tools/launch/keyboard_teleop.launch
@@ -10,5 +10,7 @@
 
   <node pkg="ca_tools" type="turtlebot_teleop_key" name="turtlebot_teleop_keyboard"
         ns="$(arg ns)" output="screen"
-        if="$(eval str(arg('robot_id')).isdigit() and (arg('robot_id') > 0) and arg('type')=='turtlebot' )"/>
+        if="$(eval str(arg('robot_id')).isdigit() and (arg('robot_id') > 0) and arg('type')=='turtlebot' )">
+      <remap from="cmd_vel" to="mobile_base/commands/velocity"/>
+  </node>
 </launch>


### PR DESCRIPTION
# Description

This PR adds a custom plugin that publishes the wheel odometry without any offset so it always starts at (0,0).

- [ ] Compare with `<odometrySource>encoder</odometrySource>` in original `gazebo_ros_pkgs`

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Run Gazebo with RViz
RVIZ=true roslaunch ca_gazebo create_house.launch
```

**Test Configuration**:

- [ ] Real robot
- [x] Gazebo simulation
- [ ] Other (please specify)

# Checklist:

- [ ] My code follows the style guidelines of this project (Travis CI is passing)
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
