### PR TITLE
Fix odom vel in diff-drive plugin when the robot is moving backward

### DIFF
--- a/ca_description/urdf/create_base_gazebo.xacro
+++ b/ca_description/urdf/create_base_gazebo.xacro
@@ -7,7 +7,7 @@
 
       <!-- Diff-drive controller -->
       <xacro:unless value="$(arg enable_ros_control)">
-        <plugin name="differential_drive_controller" filename="libgazebo_ros_diff_drive.so">
+        <plugin name="differential_drive_controller" filename="libcreate_diff_drive.so">
           <alwaysOn>true</alwaysOn>
           <rosDebugLevel>na</rosDebugLevel>
           <updateRate>30</updateRate>
@@ -21,7 +21,7 @@
           <odometryTopic>odom</odometryTopic>
           <odometryFrame>odom</odometryFrame>
           <robotBaseFrame>base_footprint</robotBaseFrame>
-          <publishWheelTF>true</publishWheelTF>
+          <publishWheelTF>false</publishWheelTF>
           <publishOdomTF>false</publishOdomTF>
           <publishWheelJointState>true</publishWheelJointState>
           <odometrySource>encoder</odometrySource>

--- a/ca_gazebo/CMakeLists.txt
+++ b/ca_gazebo/CMakeLists.txt
@@ -35,6 +35,7 @@ set(PLUGIN_LIST
   cliff_msg_publisher
   create_bumper_plugin
   create_cliff_plugin
+  create_diff_drive
   create_virtual_wall_plugin
   model_pose_publisher_plugin
   traffic_light_plugin

--- a/ca_gazebo/include/ca_gazebo/create_diff_drive.h
+++ b/ca_gazebo/include/ca_gazebo/create_diff_drive.h
@@ -1,0 +1,158 @@
+/*
+ * Copyright (c) 2010, Daniel Hewlett, Antons Rebguns
+ *  All rights reserved.
+ *
+ *  Redistribution and use in source and binary forms, with or without
+ *  modification, are permitted provided that the following conditions are met:
+ *      * Redistributions of source code must retain the above copyright
+ *      notice, this list of conditions and the following disclaimer.
+ *      * Redistributions in binary form must reproduce the above copyright
+ *      notice, this list of conditions and the following disclaimer in the
+ *      documentation and/or other materials provided with the distribution.
+ *      * Neither the name of the <organization> nor the
+ *      names of its contributors may be used to endorse or promote products
+ *      derived from this software without specific prior written permission.
+ *
+ *  THIS SOFTWARE IS PROVIDED BY Antons Rebguns <email> ''AS IS'' AND ANY
+ *  EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+ *  WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+ *  DISCLAIMED. IN NO EVENT SHALL Antons Rebguns <email> BE LIABLE FOR ANY
+ *  DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+ *  (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+ *  LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+ *  ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+ *  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+ *  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+ *
+ **/
+
+/*
+ * \file  gazebo_ros_diff_drive.h
+ *
+ * \brief A differential drive plugin for gazebo. Based on the diffdrive plugin
+ * developed for the erratic robot (see copyright notice above). The original
+ * plugin can be found in the ROS package gazebo_erratic_plugins.
+ *
+ * \author  Piyush Khandelwal (piyushk@gmail.com)
+ *
+ * $ Id: 06/21/2013 11:23:40 AM piyushk $
+ */
+
+#ifndef DIFFDRIVE_PLUGIN_HH
+#define DIFFDRIVE_PLUGIN_HH
+
+#include <map>
+
+// Gazebo
+#include <gazebo/common/common.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo_plugins/gazebo_ros_utils.h>
+
+// ROS
+#include <ros/ros.h>
+#include <tf/transform_broadcaster.h>
+#include <tf/transform_listener.h>
+#include <geometry_msgs/Twist.h>
+#include <geometry_msgs/Pose2D.h>
+#include <nav_msgs/Odometry.h>
+#include <sensor_msgs/JointState.h>
+
+// Custom Callback Queue
+#include <ros/callback_queue.h>
+#include <ros/advertise_options.h>
+
+// Boost
+#include <boost/thread.hpp>
+#include <boost/bind.hpp>
+
+namespace gazebo {
+
+  class Joint;
+  class Entity;
+
+  class GazeboRosDiffDrive : public ModelPlugin {
+
+    enum OdomSource
+    {
+        ENCODER = 0,
+        WORLD = 1,
+    };
+    public:
+      GazeboRosDiffDrive();
+      ~GazeboRosDiffDrive();
+      void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+      void Reset();
+
+    protected:
+      virtual void UpdateChild();
+      virtual void FiniChild();
+
+    private:
+      void publishOdometry(double step_time);
+      void getWheelVelocities();
+      void publishWheelTF(); /// publishes the wheel tf's
+      void publishWheelJointState();
+      void UpdateOdometryEncoder();
+
+
+      GazeboRosPtr gazebo_ros_;
+      physics::ModelPtr parent;
+      event::ConnectionPtr update_connection_;
+
+      double wheel_separation_;
+      double wheel_diameter_;
+      double wheel_torque;
+      double wheel_speed_[2];
+	  double wheel_accel;
+      double wheel_speed_instr_[2];
+
+      std::vector<physics::JointPtr> joints_;
+
+      // ROS STUFF
+      ros::Publisher odometry_publisher_;
+      ros::Subscriber cmd_vel_subscriber_;
+      boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
+      sensor_msgs::JointState joint_state_;
+      ros::Publisher joint_state_publisher_;
+      nav_msgs::Odometry odom_;
+      std::string tf_prefix_;
+
+      boost::mutex lock;
+
+      std::string robot_namespace_;
+      std::string command_topic_;
+      std::string odometry_topic_;
+      std::string odometry_frame_;
+      std::string robot_base_frame_;
+      bool publish_tf_;
+      // Custom Callback Queue
+      ros::CallbackQueue queue_;
+      boost::thread callback_queue_thread_;
+      void QueueThread();
+
+      // DiffDrive stuff
+      void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
+
+      double x_;
+      double rot_;
+      bool alive_;
+
+      // Update Rate
+      double update_rate_;
+      double update_period_;
+      common::Time last_update_time_;
+
+      OdomSource odom_source_;
+      geometry_msgs::Pose2D pose_encoder_;
+      common::Time last_odom_update_;
+
+    // Flags
+    bool publishWheelTF_;
+    bool publishOdomTF_;
+    bool publishWheelJointState_;
+
+  };
+
+}
+
+#endif

--- a/ca_gazebo/include/ca_gazebo/create_diff_drive.h
+++ b/ca_gazebo/include/ca_gazebo/create_diff_drive.h
@@ -38,10 +38,12 @@
  * $ Id: 06/21/2013 11:23:40 AM piyushk $
  */
 
-#ifndef DIFFDRIVE_PLUGIN_HH
-#define DIFFDRIVE_PLUGIN_HH
+#ifndef CA_GAZEBO_CREATE_DIFF_DRIVE_H
+#define CA_GAZEBO_CREATE_DIFF_DRIVE_H
 
 #include <map>
+#include <string>
+#include <vector>
 
 // Gazebo
 #include <gazebo/common/common.hh>
@@ -67,92 +69,92 @@
 
 namespace gazebo {
 
-  class Joint;
-  class Entity;
+class Joint;
+class Entity;
 
-  class GazeboRosDiffDrive : public ModelPlugin {
-
-    enum OdomSource
-    {
-        ENCODER = 0,
-        WORLD = 1,
-    };
-    public:
-      GazeboRosDiffDrive();
-      ~GazeboRosDiffDrive();
-      void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
-      void Reset();
-
-    protected:
-      virtual void UpdateChild();
-      virtual void FiniChild();
-
-    private:
-      void publishOdometry(double step_time);
-      void getWheelVelocities();
-      void publishWheelTF(); /// publishes the wheel tf's
-      void publishWheelJointState();
-      void UpdateOdometryEncoder();
-
-
-      GazeboRosPtr gazebo_ros_;
-      physics::ModelPtr parent;
-      event::ConnectionPtr update_connection_;
-
-      double wheel_separation_;
-      double wheel_diameter_;
-      double wheel_torque;
-      double wheel_speed_[2];
-	  double wheel_accel;
-      double wheel_speed_instr_[2];
-
-      std::vector<physics::JointPtr> joints_;
-
-      // ROS STUFF
-      ros::Publisher odometry_publisher_;
-      ros::Subscriber cmd_vel_subscriber_;
-      boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
-      sensor_msgs::JointState joint_state_;
-      ros::Publisher joint_state_publisher_;
-      nav_msgs::Odometry odom_;
-      std::string tf_prefix_;
-
-      boost::mutex lock;
-
-      std::string robot_namespace_;
-      std::string command_topic_;
-      std::string odometry_topic_;
-      std::string odometry_frame_;
-      std::string robot_base_frame_;
-      bool publish_tf_;
-      // Custom Callback Queue
-      ros::CallbackQueue queue_;
-      boost::thread callback_queue_thread_;
-      void QueueThread();
-
-      // DiffDrive stuff
-      void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
-
-      double x_;
-      double rot_;
-      bool alive_;
-
-      // Update Rate
-      double update_rate_;
-      double update_period_;
-      common::Time last_update_time_;
-
-      OdomSource odom_source_;
-      geometry_msgs::Pose2D pose_encoder_;
-      common::Time last_odom_update_;
-
-    // Flags
-    bool publishWheelTF_;
-    bool publishOdomTF_;
-    bool publishWheelJointState_;
-
+class GazeboRosDiffDrive : public ModelPlugin
+{
+  enum OdomSource
+  {
+      ENCODER = 0,
+      WORLD = 1,
   };
 
-}
+  public:
+    GazeboRosDiffDrive();
+    ~GazeboRosDiffDrive();
+    void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+    void Reset();
 
-#endif
+  protected:
+    virtual void UpdateChild();
+    virtual void FiniChild();
+
+  private:
+    void publishOdometry(double step_time);
+    void getWheelVelocities();
+    void publishWheelTF();  /// publishes the wheel tf's
+    void publishWheelJointState();
+    void UpdateOdometryEncoder();
+
+
+    GazeboRosPtr gazebo_ros_;
+    physics::ModelPtr parent;
+    event::ConnectionPtr update_connection_;
+
+    double wheel_separation_;
+    double wheel_diameter_;
+    double wheel_torque;
+    double wheel_speed_[2];
+    double wheel_accel;
+    double wheel_speed_instr_[2];
+
+    std::vector<physics::JointPtr> joints_;
+
+    // ROS STUFF
+    ros::Publisher odometry_publisher_;
+    ros::Subscriber cmd_vel_subscriber_;
+    boost::shared_ptr<tf::TransformBroadcaster> transform_broadcaster_;
+    sensor_msgs::JointState joint_state_;
+    ros::Publisher joint_state_publisher_;
+    nav_msgs::Odometry odom_;
+    std::string tf_prefix_;
+
+    boost::mutex lock;
+
+    std::string robot_namespace_;
+    std::string command_topic_;
+    std::string odometry_topic_;
+    std::string odometry_frame_;
+    std::string robot_base_frame_;
+    bool publish_tf_;
+    // Custom Callback Queue
+    ros::CallbackQueue queue_;
+    boost::thread callback_queue_thread_;
+    void QueueThread();
+
+    // DiffDrive stuff
+    void cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg);
+
+    double x_;
+    double rot_;
+    bool alive_;
+
+    // Update Rate
+    double update_rate_;
+    double update_period_;
+    common::Time last_update_time_;
+
+    OdomSource odom_source_;
+    geometry_msgs::Pose2D pose_encoder_;
+    common::Time last_odom_update_;
+
+  // Flags
+  bool publishWheelTF_;
+  bool publishOdomTF_;
+  bool publishWheelJointState_;
+};
+
+}  // namespace gazebo
+
+#endif  // CA_GAZEBO_CREATE_DIFF_DRIVE_H

--- a/ca_gazebo/src/create_diff_drive.cpp
+++ b/ca_gazebo/src/create_diff_drive.cpp
@@ -1,0 +1,473 @@
+/*
+    Copyright (c) 2010, Daniel Hewlett, Antons Rebguns
+    All rights reserved.
+
+    Redistribution and use in source and binary forms, with or without
+    modification, are permitted provided that the following conditions are met:
+        * Redistributions of source code must retain the above copyright
+        notice, this list of conditions and the following disclaimer.
+        * Redistributions in binary form must reproduce the above copyright
+        notice, this list of conditions and the following disclaimer in the
+        documentation and/or other materials provided with the distribution.
+        * Neither the name of the <organization> nor the
+        names of its contributors may be used to endorse or promote products
+        derived from this software without specific prior written permission.
+
+    THIS SOFTWARE IS PROVIDED BY Antons Rebguns <email> ''AS IS'' AND ANY
+    EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+    WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+    DISCLAIMED. IN NO EVENT SHALL Antons Rebguns <email> BE LIABLE FOR ANY
+    DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+    (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+    LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND
+    ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+    (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+    SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+*/
+
+/*
+ * \file  gazebo_ros_diff_drive.cpp
+ *
+ * \brief A differential drive plugin for gazebo. Based on the diffdrive plugin
+ * developed for the erratic robot (see copyright notice above). The original
+ * plugin can be found in the ROS package gazebo_erratic_plugins.
+ *
+ * \author  Piyush Khandelwal (piyushk@gmail.com)
+ *
+ * $ Id: 06/21/2013 11:23:40 AM piyushk $
+ */
+
+
+/*
+ *
+ * The support of acceleration limit was added by
+ * \author   George Todoran <todorangrg@gmail.com>
+ * \author   Markus Bader <markus.bader@tuwien.ac.at>
+ * \date 22th of May 2014
+ */
+
+#include <algorithm>
+#include <assert.h>
+
+#include <ca_gazebo/create_diff_drive.h>
+
+#include <ignition/math/Angle.hh>
+#include <ignition/math/Pose3.hh>
+#include <ignition/math/Quaternion.hh>
+#include <ignition/math/Vector3.hh>
+#include <sdf/sdf.hh>
+
+#include <ros/ros.h>
+
+namespace gazebo
+{
+
+enum {
+    RIGHT,
+    LEFT,
+};
+
+GazeboRosDiffDrive::GazeboRosDiffDrive() {}
+
+// Destructor
+GazeboRosDiffDrive::~GazeboRosDiffDrive()
+{
+    FiniChild();
+}
+
+// Load the controller
+void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf )
+{
+
+    this->parent = _parent;
+    gazebo_ros_ = GazeboRosPtr ( new GazeboRos ( _parent, _sdf, "DiffDrive" ) );
+    // Make sure the ROS node for Gazebo has already been initialized
+    gazebo_ros_->isInitialized();
+
+    gazebo_ros_->getParameter<std::string> ( command_topic_, "commandTopic", "cmd_vel" );
+    gazebo_ros_->getParameter<std::string> ( odometry_topic_, "odometryTopic", "odom" );
+    gazebo_ros_->getParameter<std::string> ( odometry_frame_, "odometryFrame", "odom" );
+    gazebo_ros_->getParameter<std::string> ( robot_base_frame_, "robotBaseFrame", "base_footprint" );
+    gazebo_ros_->getParameterBoolean ( publishWheelTF_, "publishWheelTF", false );
+    gazebo_ros_->getParameterBoolean ( publishOdomTF_, "publishOdomTF", true);
+    gazebo_ros_->getParameterBoolean ( publishWheelJointState_, "publishWheelJointState", false );
+    gazebo_ros_->getParameter<double> ( wheel_separation_, "wheelSeparation", 0.34 );
+    gazebo_ros_->getParameter<double> ( wheel_diameter_, "wheelDiameter", 0.15 );
+    gazebo_ros_->getParameter<double> ( wheel_accel, "wheelAcceleration", 0.0 );
+    gazebo_ros_->getParameter<double> ( wheel_torque, "wheelTorque", 5.0 );
+    gazebo_ros_->getParameter<double> ( update_rate_, "updateRate", 100.0 );
+    std::map<std::string, OdomSource> odomOptions;
+    odomOptions["encoder"] = ENCODER;
+    odomOptions["world"] = WORLD;
+    gazebo_ros_->getParameter<OdomSource> ( odom_source_, "odometrySource", odomOptions, WORLD );
+
+
+    joints_.resize ( 2 );
+    joints_[LEFT] = gazebo_ros_->getJoint ( parent, "leftJoint", "left_joint" );
+    joints_[RIGHT] = gazebo_ros_->getJoint ( parent, "rightJoint", "right_joint" );
+    joints_[LEFT]->SetParam ( "fmax", 0, wheel_torque );
+    joints_[RIGHT]->SetParam ( "fmax", 0, wheel_torque );
+
+
+
+    this->publish_tf_ = true;
+    if (!_sdf->HasElement("publishTf")) {
+      ROS_WARN_NAMED("diff_drive", "GazeboRosDiffDrive Plugin (ns = %s) missing <publishTf>, defaults to %d",
+          this->robot_namespace_.c_str(), this->publish_tf_);
+    } else {
+      this->publish_tf_ = _sdf->GetElement("publishTf")->Get<bool>();
+    }
+
+    // Initialize update rate stuff
+    if ( this->update_rate_ > 0.0 ) this->update_period_ = 1.0 / this->update_rate_;
+    else this->update_period_ = 0.0;
+#if GAZEBO_MAJOR_VERSION >= 8
+    last_update_time_ = parent->GetWorld()->SimTime();
+#else
+    last_update_time_ = parent->GetWorld()->GetSimTime();
+#endif
+
+    // Initialize velocity stuff
+    wheel_speed_[RIGHT] = 0;
+    wheel_speed_[LEFT] = 0;
+
+    // Initialize velocity support stuff
+    wheel_speed_instr_[RIGHT] = 0;
+    wheel_speed_instr_[LEFT] = 0;
+
+    x_ = 0;
+    rot_ = 0;
+    alive_ = true;
+
+
+    if (this->publishWheelJointState_)
+    {
+        joint_state_publisher_ = gazebo_ros_->node()->advertise<sensor_msgs::JointState>("joint_states", 1000);
+        ROS_INFO_NAMED("diff_drive", "%s: Advertise joint_states", gazebo_ros_->info());
+    }
+
+    transform_broadcaster_ = boost::shared_ptr<tf::TransformBroadcaster>(new tf::TransformBroadcaster());
+
+    // ROS: Subscribe to the velocity command topic (usually "cmd_vel")
+    ROS_INFO_NAMED("diff_drive", "%s: Try to subscribe to %s", gazebo_ros_->info(), command_topic_.c_str());
+
+    ros::SubscribeOptions so =
+        ros::SubscribeOptions::create<geometry_msgs::Twist>(command_topic_, 1,
+                boost::bind(&GazeboRosDiffDrive::cmdVelCallback, this, _1),
+                ros::VoidPtr(), &queue_);
+
+    cmd_vel_subscriber_ = gazebo_ros_->node()->subscribe(so);
+    ROS_INFO_NAMED("diff_drive", "%s: Subscribe to %s", gazebo_ros_->info(), command_topic_.c_str());
+
+    if (this->publish_tf_)
+    {
+      odometry_publisher_ = gazebo_ros_->node()->advertise<nav_msgs::Odometry>(odometry_topic_, 1);
+      ROS_INFO_NAMED("diff_drive", "%s: Advertise odom on %s ", gazebo_ros_->info(), odometry_topic_.c_str());
+    }
+
+    // start custom queue for diff drive
+    this->callback_queue_thread_ =
+        boost::thread ( boost::bind ( &GazeboRosDiffDrive::QueueThread, this ) );
+
+    // listen to the update event (broadcast every simulation iteration)
+    this->update_connection_ =
+        event::Events::ConnectWorldUpdateBegin ( boost::bind ( &GazeboRosDiffDrive::UpdateChild, this ) );
+
+}
+
+void GazeboRosDiffDrive::Reset()
+{
+#if GAZEBO_MAJOR_VERSION >= 8
+  last_update_time_ = parent->GetWorld()->SimTime();
+#else
+  last_update_time_ = parent->GetWorld()->GetSimTime();
+#endif
+  pose_encoder_.x = 0;
+  pose_encoder_.y = 0;
+  pose_encoder_.theta = 0;
+  x_ = 0;
+  rot_ = 0;
+  joints_[LEFT]->SetParam ( "fmax", 0, wheel_torque );
+  joints_[RIGHT]->SetParam ( "fmax", 0, wheel_torque );
+}
+
+void GazeboRosDiffDrive::publishWheelJointState()
+{
+    ros::Time current_time = ros::Time::now();
+
+    joint_state_.header.stamp = current_time;
+    joint_state_.name.resize ( joints_.size() );
+    joint_state_.position.resize ( joints_.size() );
+
+    for ( int i = 0; i < 2; i++ ) {
+        physics::JointPtr joint = joints_[i];
+#if GAZEBO_MAJOR_VERSION >= 8
+        double position = joint->Position ( 0 );
+#else
+        double position = joint->GetAngle ( 0 ).Radian();
+#endif
+        joint_state_.name[i] = joint->GetName();
+        joint_state_.position[i] = position;
+    }
+    joint_state_publisher_.publish ( joint_state_ );
+}
+
+void GazeboRosDiffDrive::publishWheelTF()
+{
+    ros::Time current_time = ros::Time::now();
+    for ( int i = 0; i < 2; i++ ) {
+
+        std::string wheel_frame = gazebo_ros_->resolveTF(joints_[i]->GetChild()->GetName ());
+        std::string wheel_parent_frame = gazebo_ros_->resolveTF(joints_[i]->GetParent()->GetName ());
+
+#if GAZEBO_MAJOR_VERSION >= 8
+        ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->RelativePose();
+#else
+        ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->GetRelativePose().Ign();
+#endif
+
+        tf::Quaternion qt ( poseWheel.Rot().X(), poseWheel.Rot().Y(), poseWheel.Rot().Z(), poseWheel.Rot().W() );
+        tf::Vector3 vt ( poseWheel.Pos().X(), poseWheel.Pos().Y(), poseWheel.Pos().Z() );
+
+        tf::Transform tfWheel ( qt, vt );
+        transform_broadcaster_->sendTransform (
+            tf::StampedTransform ( tfWheel, current_time, wheel_parent_frame, wheel_frame ) );
+    }
+}
+
+// Update the controller
+void GazeboRosDiffDrive::UpdateChild()
+{
+
+    /* force reset SetParam("fmax") since Joint::Reset reset MaxForce to zero at
+       https://bitbucket.org/osrf/gazebo/src/8091da8b3c529a362f39b042095e12c94656a5d1/gazebo/physics/Joint.cc?at=gazebo2_2.2.5#cl-331
+       (this has been solved in https://bitbucket.org/osrf/gazebo/diff/gazebo/physics/Joint.cc?diff2=b64ff1b7b6ff&at=issue_964 )
+       and Joint::Reset is called after ModelPlugin::Reset, so we need to set maxForce to wheel_torque other than GazeboRosDiffDrive::Reset
+       (this seems to be solved in https://bitbucket.org/osrf/gazebo/commits/ec8801d8683160eccae22c74bf865d59fac81f1e)
+    */
+    for ( int i = 0; i < 2; i++ ) {
+      if ( fabs(wheel_torque -joints_[i]->GetParam ( "fmax", 0 )) > 1e-6 ) {
+        joints_[i]->SetParam ( "fmax", 0, wheel_torque );
+      }
+    }
+
+
+    if ( odom_source_ == ENCODER ) UpdateOdometryEncoder();
+#if GAZEBO_MAJOR_VERSION >= 8
+    common::Time current_time = parent->GetWorld()->SimTime();
+#else
+    common::Time current_time = parent->GetWorld()->GetSimTime();
+#endif
+    double seconds_since_last_update = ( current_time - last_update_time_ ).Double();
+
+    if ( seconds_since_last_update > update_period_ ) {
+        if (this->publish_tf_) publishOdometry ( seconds_since_last_update );
+        if ( publishWheelTF_ ) publishWheelTF();
+        if ( publishWheelJointState_ ) publishWheelJointState();
+
+        // Update robot in case new velocities have been requested
+        getWheelVelocities();
+
+        double current_speed[2];
+
+        current_speed[LEFT] = joints_[LEFT]->GetVelocity ( 0 )   * ( wheel_diameter_ / 2.0 );
+        current_speed[RIGHT] = joints_[RIGHT]->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
+
+        if ( wheel_accel == 0 ||
+                ( fabs ( wheel_speed_[LEFT] - current_speed[LEFT] ) < 0.01 ) ||
+                ( fabs ( wheel_speed_[RIGHT] - current_speed[RIGHT] ) < 0.01 ) ) {
+            //if max_accel == 0, or target speed is reached
+            joints_[LEFT]->SetParam ( "vel", 0, wheel_speed_[LEFT]/ ( wheel_diameter_ / 2.0 ) );
+            joints_[RIGHT]->SetParam ( "vel", 0, wheel_speed_[RIGHT]/ ( wheel_diameter_ / 2.0 ) );
+        } else {
+            if ( wheel_speed_[LEFT]>=current_speed[LEFT] )
+                wheel_speed_instr_[LEFT]+=fmin ( wheel_speed_[LEFT]-current_speed[LEFT],  wheel_accel * seconds_since_last_update );
+            else
+                wheel_speed_instr_[LEFT]+=fmax ( wheel_speed_[LEFT]-current_speed[LEFT], -wheel_accel * seconds_since_last_update );
+
+            if ( wheel_speed_[RIGHT]>current_speed[RIGHT] )
+                wheel_speed_instr_[RIGHT]+=fmin ( wheel_speed_[RIGHT]-current_speed[RIGHT], wheel_accel * seconds_since_last_update );
+            else
+                wheel_speed_instr_[RIGHT]+=fmax ( wheel_speed_[RIGHT]-current_speed[RIGHT], -wheel_accel * seconds_since_last_update );
+
+            // ROS_INFO_NAMED("diff_drive", "actual wheel speed = %lf, issued wheel speed= %lf", current_speed[LEFT], wheel_speed_[LEFT]);
+            // ROS_INFO_NAMED("diff_drive", "actual wheel speed = %lf, issued wheel speed= %lf", current_speed[RIGHT],wheel_speed_[RIGHT]);
+
+            joints_[LEFT]->SetParam ( "vel", 0, wheel_speed_instr_[LEFT] / ( wheel_diameter_ / 2.0 ) );
+            joints_[RIGHT]->SetParam ( "vel", 0, wheel_speed_instr_[RIGHT] / ( wheel_diameter_ / 2.0 ) );
+        }
+        last_update_time_+= common::Time ( update_period_ );
+    }
+}
+
+// Finalize the controller
+void GazeboRosDiffDrive::FiniChild()
+{
+    alive_ = false;
+    queue_.clear();
+    queue_.disable();
+    gazebo_ros_->node()->shutdown();
+    callback_queue_thread_.join();
+}
+
+void GazeboRosDiffDrive::getWheelVelocities()
+{
+    boost::mutex::scoped_lock scoped_lock ( lock );
+
+    double vr = x_;
+    double va = rot_;
+
+    wheel_speed_[LEFT] = vr - va * wheel_separation_ / 2.0;
+    wheel_speed_[RIGHT] = vr + va * wheel_separation_ / 2.0;
+}
+
+void GazeboRosDiffDrive::cmdVelCallback ( const geometry_msgs::Twist::ConstPtr& cmd_msg )
+{
+    boost::mutex::scoped_lock scoped_lock ( lock );
+    x_ = cmd_msg->linear.x;
+    rot_ = cmd_msg->angular.z;
+}
+
+void GazeboRosDiffDrive::QueueThread()
+{
+    static const double timeout = 0.01;
+
+    while ( alive_ && gazebo_ros_->node()->ok() ) {
+        queue_.callAvailable ( ros::WallDuration ( timeout ) );
+    }
+}
+
+void GazeboRosDiffDrive::UpdateOdometryEncoder()
+{
+    double vl = joints_[LEFT]->GetVelocity ( 0 );
+    double vr = joints_[RIGHT]->GetVelocity ( 0 );
+#if GAZEBO_MAJOR_VERSION >= 8
+    common::Time current_time = parent->GetWorld()->SimTime();
+#else
+    common::Time current_time = parent->GetWorld()->GetSimTime();
+#endif
+    double seconds_since_last_update = ( current_time - last_odom_update_ ).Double();
+    last_odom_update_ = current_time;
+
+    double b = wheel_separation_;
+
+    // Book: Sigwart 2011 Autonompus Mobile Robots page:337
+    double sl = vl * ( wheel_diameter_ / 2.0 ) * seconds_since_last_update;
+    double sr = vr * ( wheel_diameter_ / 2.0 ) * seconds_since_last_update;
+    double ssum = sl + sr;
+
+    double sdiff = sr - sl;
+
+    double dx = ( ssum ) /2.0 * cos ( pose_encoder_.theta + ( sdiff ) / ( 2.0*b ) );
+    double dy = ( ssum ) /2.0 * sin ( pose_encoder_.theta + ( sdiff ) / ( 2.0*b ) );
+    double dtheta = ( sdiff ) /b;
+
+    pose_encoder_.x += dx;
+    pose_encoder_.y += dy;
+    pose_encoder_.theta += dtheta;
+
+    double w = dtheta/seconds_since_last_update;
+    double v = sqrt ( dx*dx+dy*dy ) /seconds_since_last_update;
+
+    tf::Quaternion qt;
+    tf::Vector3 vt;
+    qt.setRPY ( 0,0,pose_encoder_.theta );
+    vt = tf::Vector3 ( pose_encoder_.x, pose_encoder_.y, 0 );
+
+    odom_.pose.pose.position.x = vt.x();
+    odom_.pose.pose.position.y = vt.y();
+    odom_.pose.pose.position.z = vt.z();
+
+    odom_.pose.pose.orientation.x = qt.x();
+    odom_.pose.pose.orientation.y = qt.y();
+    odom_.pose.pose.orientation.z = qt.z();
+    odom_.pose.pose.orientation.w = qt.w();
+
+    odom_.twist.twist.angular.z = w;
+    if (ssum<0) {
+        odom_.twist.twist.linear.x = -v;
+    }
+    else {
+        odom_.twist.twist.linear.x = v;
+    }
+    odom_.twist.twist.linear.y = 0;
+}
+
+void GazeboRosDiffDrive::publishOdometry ( double step_time )
+{
+
+    ros::Time current_time = ros::Time::now();
+    std::string odom_frame = gazebo_ros_->resolveTF ( odometry_frame_ );
+    std::string base_footprint_frame = gazebo_ros_->resolveTF ( robot_base_frame_ );
+
+    tf::Quaternion qt;
+    tf::Vector3 vt;
+
+    if ( odom_source_ == ENCODER ) {
+        // getting data form encoder integration
+        qt = tf::Quaternion ( odom_.pose.pose.orientation.x, odom_.pose.pose.orientation.y, odom_.pose.pose.orientation.z, odom_.pose.pose.orientation.w );
+        vt = tf::Vector3 ( odom_.pose.pose.position.x, odom_.pose.pose.position.y, odom_.pose.pose.position.z );
+    }
+    if ( odom_source_ == WORLD ) {
+        // getting data from gazebo world
+#if GAZEBO_MAJOR_VERSION >= 8
+        ignition::math::Pose3d pose = parent->WorldPose();
+#else
+        ignition::math::Pose3d pose = parent->GetWorldPose().Ign();
+#endif
+        qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
+        vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
+
+        odom_.pose.pose.position.x = vt.x();
+        odom_.pose.pose.position.y = vt.y();
+        odom_.pose.pose.position.z = vt.z();
+
+        odom_.pose.pose.orientation.x = qt.x();
+        odom_.pose.pose.orientation.y = qt.y();
+        odom_.pose.pose.orientation.z = qt.z();
+        odom_.pose.pose.orientation.w = qt.w();
+
+        // get velocity in /odom frame
+        ignition::math::Vector3d linear;
+#if GAZEBO_MAJOR_VERSION >= 8
+        linear = parent->WorldLinearVel();
+        odom_.twist.twist.angular.z = parent->WorldAngularVel().Z();
+#else
+        linear = parent->GetWorldLinearVel().Ign();
+        odom_.twist.twist.angular.z = parent->GetWorldAngularVel().Ign().Z();
+#endif
+
+        // convert velocity to child_frame_id (aka base_footprint)
+        float yaw = pose.Rot().Yaw();
+        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.X() + sinf ( yaw ) * linear.Y();
+        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.Y() - sinf ( yaw ) * linear.X();
+    }
+
+    if (publishOdomTF_ == true){
+        tf::Transform base_footprint_to_odom ( qt, vt );
+        transform_broadcaster_->sendTransform (
+            tf::StampedTransform ( base_footprint_to_odom, current_time,
+                                   odom_frame, base_footprint_frame ) );
+    }
+
+
+    // set covariance
+    odom_.pose.covariance[0] = 0.00001;
+    odom_.pose.covariance[7] = 0.00001;
+    odom_.pose.covariance[14] = 1000000000000.0;
+    odom_.pose.covariance[21] = 1000000000000.0;
+    odom_.pose.covariance[28] = 1000000000000.0;
+    odom_.pose.covariance[35] = 0.001;
+
+
+    // set header
+    odom_.header.stamp = current_time;
+    odom_.header.frame_id = odom_frame;
+    odom_.child_frame_id = base_footprint_frame;
+
+    odometry_publisher_.publish ( odom_ );
+}
+
+GZ_REGISTER_MODEL_PLUGIN ( GazeboRosDiffDrive )
+}

--- a/ca_gazebo/src/create_diff_drive.cpp
+++ b/ca_gazebo/src/create_diff_drive.cpp
@@ -49,6 +49,8 @@
 
 #include <algorithm>
 #include <assert.h>
+#include <map>
+#include <string>
 
 #include <ca_gazebo/create_diff_drive.h>
 
@@ -77,39 +79,36 @@ GazeboRosDiffDrive::~GazeboRosDiffDrive()
 }
 
 // Load the controller
-void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf )
+void GazeboRosDiffDrive::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
 {
-
     this->parent = _parent;
     gazebo_ros_ = GazeboRosPtr ( new GazeboRos ( _parent, _sdf, "DiffDrive" ) );
     // Make sure the ROS node for Gazebo has already been initialized
     gazebo_ros_->isInitialized();
 
-    gazebo_ros_->getParameter<std::string> ( command_topic_, "commandTopic", "cmd_vel" );
-    gazebo_ros_->getParameter<std::string> ( odometry_topic_, "odometryTopic", "odom" );
-    gazebo_ros_->getParameter<std::string> ( odometry_frame_, "odometryFrame", "odom" );
-    gazebo_ros_->getParameter<std::string> ( robot_base_frame_, "robotBaseFrame", "base_footprint" );
-    gazebo_ros_->getParameterBoolean ( publishWheelTF_, "publishWheelTF", false );
-    gazebo_ros_->getParameterBoolean ( publishOdomTF_, "publishOdomTF", true);
-    gazebo_ros_->getParameterBoolean ( publishWheelJointState_, "publishWheelJointState", false );
-    gazebo_ros_->getParameter<double> ( wheel_separation_, "wheelSeparation", 0.34 );
-    gazebo_ros_->getParameter<double> ( wheel_diameter_, "wheelDiameter", 0.15 );
-    gazebo_ros_->getParameter<double> ( wheel_accel, "wheelAcceleration", 0.0 );
-    gazebo_ros_->getParameter<double> ( wheel_torque, "wheelTorque", 5.0 );
-    gazebo_ros_->getParameter<double> ( update_rate_, "updateRate", 100.0 );
+    gazebo_ros_->getParameter<std::string> (command_topic_, "commandTopic", "cmd_vel");
+    gazebo_ros_->getParameter<std::string> (odometry_topic_, "odometryTopic", "odom");
+    gazebo_ros_->getParameter<std::string> (odometry_frame_, "odometryFrame", "odom");
+    gazebo_ros_->getParameter<std::string> (robot_base_frame_, "robotBaseFrame", "base_footprint");
+    gazebo_ros_->getParameterBoolean(publishWheelTF_, "publishWheelTF", false);
+    gazebo_ros_->getParameterBoolean(publishOdomTF_, "publishOdomTF", true);
+    gazebo_ros_->getParameterBoolean(publishWheelJointState_, "publishWheelJointState", false);
+    gazebo_ros_->getParameter<double> (wheel_separation_, "wheelSeparation", 0.34);
+    gazebo_ros_->getParameter<double> (wheel_diameter_, "wheelDiameter", 0.15);
+    gazebo_ros_->getParameter<double> (wheel_accel, "wheelAcceleration", 0.0);
+    gazebo_ros_->getParameter<double> (wheel_torque, "wheelTorque", 5.0);
+    gazebo_ros_->getParameter<double> (update_rate_, "updateRate", 100.0);
     std::map<std::string, OdomSource> odomOptions;
     odomOptions["encoder"] = ENCODER;
     odomOptions["world"] = WORLD;
-    gazebo_ros_->getParameter<OdomSource> ( odom_source_, "odometrySource", odomOptions, WORLD );
+    gazebo_ros_->getParameter<OdomSource>(odom_source_, "odometrySource", odomOptions, WORLD);
 
 
-    joints_.resize ( 2 );
-    joints_[LEFT] = gazebo_ros_->getJoint ( parent, "leftJoint", "left_joint" );
-    joints_[RIGHT] = gazebo_ros_->getJoint ( parent, "rightJoint", "right_joint" );
-    joints_[LEFT]->SetParam ( "fmax", 0, wheel_torque );
-    joints_[RIGHT]->SetParam ( "fmax", 0, wheel_torque );
-
-
+    joints_.resize(2);
+    joints_[LEFT] = gazebo_ros_->getJoint(parent, "leftJoint", "left_joint");
+    joints_[RIGHT] = gazebo_ros_->getJoint(parent, "rightJoint", "right_joint");
+    joints_[LEFT]->SetParam("fmax", 0, wheel_torque);
+    joints_[RIGHT]->SetParam("fmax", 0, wheel_torque);
 
     this->publish_tf_ = true;
     if (!_sdf->HasElement("publishTf")) {
@@ -168,12 +167,11 @@ void GazeboRosDiffDrive::Load ( physics::ModelPtr _parent, sdf::ElementPtr _sdf 
 
     // start custom queue for diff drive
     this->callback_queue_thread_ =
-        boost::thread ( boost::bind ( &GazeboRosDiffDrive::QueueThread, this ) );
+        boost::thread(boost::bind(&GazeboRosDiffDrive::QueueThread, this));
 
     // listen to the update event (broadcast every simulation iteration)
     this->update_connection_ =
-        event::Events::ConnectWorldUpdateBegin ( boost::bind ( &GazeboRosDiffDrive::UpdateChild, this ) );
-
+        event::Events::ConnectWorldUpdateBegin(boost::bind(&GazeboRosDiffDrive::UpdateChild, this));
 }
 
 void GazeboRosDiffDrive::Reset()
@@ -188,8 +186,8 @@ void GazeboRosDiffDrive::Reset()
   pose_encoder_.theta = 0;
   x_ = 0;
   rot_ = 0;
-  joints_[LEFT]->SetParam ( "fmax", 0, wheel_torque );
-  joints_[RIGHT]->SetParam ( "fmax", 0, wheel_torque );
+  joints_[LEFT]->SetParam("fmax", 0, wheel_torque);
+  joints_[RIGHT]->SetParam("fmax", 0, wheel_torque);
 }
 
 void GazeboRosDiffDrive::publishWheelJointState()
@@ -197,29 +195,29 @@ void GazeboRosDiffDrive::publishWheelJointState()
     ros::Time current_time = ros::Time::now();
 
     joint_state_.header.stamp = current_time;
-    joint_state_.name.resize ( joints_.size() );
-    joint_state_.position.resize ( joints_.size() );
+    joint_state_.name.resize(joints_.size());
+    joint_state_.position.resize(joints_.size());
 
     for ( int i = 0; i < 2; i++ ) {
         physics::JointPtr joint = joints_[i];
 #if GAZEBO_MAJOR_VERSION >= 8
-        double position = joint->Position ( 0 );
+        double position = joint->Position(0);
 #else
-        double position = joint->GetAngle ( 0 ).Radian();
+        double position = joint->GetAngle(0).Radian();
 #endif
         joint_state_.name[i] = joint->GetName();
         joint_state_.position[i] = position;
     }
-    joint_state_publisher_.publish ( joint_state_ );
+    joint_state_publisher_.publish(joint_state_);
 }
 
 void GazeboRosDiffDrive::publishWheelTF()
 {
     ros::Time current_time = ros::Time::now();
-    for ( int i = 0; i < 2; i++ ) {
-
-        std::string wheel_frame = gazebo_ros_->resolveTF(joints_[i]->GetChild()->GetName ());
-        std::string wheel_parent_frame = gazebo_ros_->resolveTF(joints_[i]->GetParent()->GetName ());
+    for ( int i = 0; i < 2; i++ )
+    {
+        std::string wheel_frame = gazebo_ros_->resolveTF(joints_[i]->GetChild()->GetName());
+        std::string wheel_parent_frame = gazebo_ros_->resolveTF(joints_[i]->GetParent()->GetName());
 
 #if GAZEBO_MAJOR_VERSION >= 8
         ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->RelativePose();
@@ -227,19 +225,18 @@ void GazeboRosDiffDrive::publishWheelTF()
         ignition::math::Pose3d poseWheel = joints_[i]->GetChild()->GetRelativePose().Ign();
 #endif
 
-        tf::Quaternion qt ( poseWheel.Rot().X(), poseWheel.Rot().Y(), poseWheel.Rot().Z(), poseWheel.Rot().W() );
-        tf::Vector3 vt ( poseWheel.Pos().X(), poseWheel.Pos().Y(), poseWheel.Pos().Z() );
+        tf::Quaternion qt(poseWheel.Rot().X(), poseWheel.Rot().Y(), poseWheel.Rot().Z(), poseWheel.Rot().W());
+        tf::Vector3 vt(poseWheel.Pos().X(), poseWheel.Pos().Y(), poseWheel.Pos().Z());
 
-        tf::Transform tfWheel ( qt, vt );
-        transform_broadcaster_->sendTransform (
-            tf::StampedTransform ( tfWheel, current_time, wheel_parent_frame, wheel_frame ) );
+        tf::Transform tfWheel(qt, vt);
+        transform_broadcaster_->sendTransform(
+            tf::StampedTransform(tfWheel, current_time, wheel_parent_frame, wheel_frame));
     }
 }
 
 // Update the controller
 void GazeboRosDiffDrive::UpdateChild()
 {
-
     /* force reset SetParam("fmax") since Joint::Reset reset MaxForce to zero at
        https://bitbucket.org/osrf/gazebo/src/8091da8b3c529a362f39b042095e12c94656a5d1/gazebo/physics/Joint.cc?at=gazebo2_2.2.5#cl-331
        (this has been solved in https://bitbucket.org/osrf/gazebo/diff/gazebo/physics/Joint.cc?diff2=b64ff1b7b6ff&at=issue_964 )
@@ -247,8 +244,9 @@ void GazeboRosDiffDrive::UpdateChild()
        (this seems to be solved in https://bitbucket.org/osrf/gazebo/commits/ec8801d8683160eccae22c74bf865d59fac81f1e)
     */
     for ( int i = 0; i < 2; i++ ) {
-      if ( fabs(wheel_torque -joints_[i]->GetParam ( "fmax", 0 )) > 1e-6 ) {
-        joints_[i]->SetParam ( "fmax", 0, wheel_torque );
+      if ( fabs(wheel_torque -joints_[i]->GetParam("fmax", 0)) > 1e-6 )
+      {
+        joints_[i]->SetParam("fmax", 0, wheel_torque);
       }
     }
 
@@ -259,7 +257,7 @@ void GazeboRosDiffDrive::UpdateChild()
 #else
     common::Time current_time = parent->GetWorld()->GetSimTime();
 #endif
-    double seconds_since_last_update = ( current_time - last_update_time_ ).Double();
+    const double seconds_since_last_update = (current_time - last_update_time_).Double();
 
     if ( seconds_since_last_update > update_period_ ) {
         if (this->publish_tf_) publishOdometry ( seconds_since_last_update );
@@ -271,33 +269,40 @@ void GazeboRosDiffDrive::UpdateChild()
 
         double current_speed[2];
 
-        current_speed[LEFT] = joints_[LEFT]->GetVelocity ( 0 )   * ( wheel_diameter_ / 2.0 );
-        current_speed[RIGHT] = joints_[RIGHT]->GetVelocity ( 0 ) * ( wheel_diameter_ / 2.0 );
+        current_speed[LEFT] = joints_[LEFT]->GetVelocity(0)   * (wheel_diameter_ / 2.0);
+        current_speed[RIGHT] = joints_[RIGHT]->GetVelocity(0) * (wheel_diameter_ / 2.0);
 
-        if ( wheel_accel == 0 ||
-                ( fabs ( wheel_speed_[LEFT] - current_speed[LEFT] ) < 0.01 ) ||
-                ( fabs ( wheel_speed_[RIGHT] - current_speed[RIGHT] ) < 0.01 ) ) {
-            //if max_accel == 0, or target speed is reached
-            joints_[LEFT]->SetParam ( "vel", 0, wheel_speed_[LEFT]/ ( wheel_diameter_ / 2.0 ) );
-            joints_[RIGHT]->SetParam ( "vel", 0, wheel_speed_[RIGHT]/ ( wheel_diameter_ / 2.0 ) );
+        if (wheel_accel == 0 ||
+            (fabs(wheel_speed_[LEFT] - current_speed[LEFT])   < 0.01) ||
+            (fabs(wheel_speed_[RIGHT] - current_speed[RIGHT]) < 0.01))
+        {
+            // if max_accel == 0, or target speed is reached
+            joints_[LEFT]->SetParam("vel", 0, wheel_speed_[LEFT] / (wheel_diameter_ / 2.0));
+            joints_[RIGHT]->SetParam("vel", 0, wheel_speed_[RIGHT] / (wheel_diameter_ / 2.0));
         } else {
-            if ( wheel_speed_[LEFT]>=current_speed[LEFT] )
-                wheel_speed_instr_[LEFT]+=fmin ( wheel_speed_[LEFT]-current_speed[LEFT],  wheel_accel * seconds_since_last_update );
+            if (wheel_speed_[LEFT] >= current_speed[LEFT])
+                wheel_speed_instr_[LEFT] += fmin(wheel_speed_[LEFT]-current_speed[LEFT],
+                                                  wheel_accel * seconds_since_last_update);
             else
-                wheel_speed_instr_[LEFT]+=fmax ( wheel_speed_[LEFT]-current_speed[LEFT], -wheel_accel * seconds_since_last_update );
+                wheel_speed_instr_[LEFT] += fmax(wheel_speed_[LEFT]-current_speed[LEFT],
+                                                 -wheel_accel * seconds_since_last_update);
 
-            if ( wheel_speed_[RIGHT]>current_speed[RIGHT] )
-                wheel_speed_instr_[RIGHT]+=fmin ( wheel_speed_[RIGHT]-current_speed[RIGHT], wheel_accel * seconds_since_last_update );
+            if ( wheel_speed_[RIGHT] > current_speed[RIGHT] )
+                wheel_speed_instr_[RIGHT] += fmin(wheel_speed_[RIGHT]-current_speed[RIGHT],
+                                                  wheel_accel * seconds_since_last_update);
             else
-                wheel_speed_instr_[RIGHT]+=fmax ( wheel_speed_[RIGHT]-current_speed[RIGHT], -wheel_accel * seconds_since_last_update );
+                wheel_speed_instr_[RIGHT] += fmax(wheel_speed_[RIGHT]-current_speed[RIGHT],
+                                                  -wheel_accel * seconds_since_last_update);
 
-            // ROS_INFO_NAMED("diff_drive", "actual wheel speed = %lf, issued wheel speed= %lf", current_speed[LEFT], wheel_speed_[LEFT]);
-            // ROS_INFO_NAMED("diff_drive", "actual wheel speed = %lf, issued wheel speed= %lf", current_speed[RIGHT],wheel_speed_[RIGHT]);
+            // ROS_INFO_NAMED("diff_drive", "actual wheel speed = %lf, issued wheel speed= %lf",
+            //                 current_speed[LEFT], wheel_speed_[LEFT]);
+            // ROS_INFO_NAMED("diff_drive", "actual wheel speed = %lf, issued wheel speed= %lf",
+            //                 current_speed[RIGHT],wheel_speed_[RIGHT]);
 
-            joints_[LEFT]->SetParam ( "vel", 0, wheel_speed_instr_[LEFT] / ( wheel_diameter_ / 2.0 ) );
-            joints_[RIGHT]->SetParam ( "vel", 0, wheel_speed_instr_[RIGHT] / ( wheel_diameter_ / 2.0 ) );
+            joints_[LEFT]->SetParam("vel", 0, wheel_speed_instr_[LEFT] / (wheel_diameter_ / 2.0));
+            joints_[RIGHT]->SetParam("vel", 0, wheel_speed_instr_[RIGHT] / (wheel_diameter_ / 2.0));
         }
-        last_update_time_+= common::Time ( update_period_ );
+        last_update_time_+= common::Time(update_period_);
     }
 }
 
@@ -313,7 +318,7 @@ void GazeboRosDiffDrive::FiniChild()
 
 void GazeboRosDiffDrive::getWheelVelocities()
 {
-    boost::mutex::scoped_lock scoped_lock ( lock );
+    boost::mutex::scoped_lock scoped_lock(lock);
 
     double vr = x_;
     double va = rot_;
@@ -322,9 +327,9 @@ void GazeboRosDiffDrive::getWheelVelocities()
     wheel_speed_[RIGHT] = vr + va * wheel_separation_ / 2.0;
 }
 
-void GazeboRosDiffDrive::cmdVelCallback ( const geometry_msgs::Twist::ConstPtr& cmd_msg )
+void GazeboRosDiffDrive::cmdVelCallback(const geometry_msgs::Twist::ConstPtr& cmd_msg)
 {
-    boost::mutex::scoped_lock scoped_lock ( lock );
+    boost::mutex::scoped_lock scoped_lock(lock);
     x_ = cmd_msg->linear.x;
     rot_ = cmd_msg->angular.z;
 }
@@ -333,47 +338,47 @@ void GazeboRosDiffDrive::QueueThread()
 {
     static const double timeout = 0.01;
 
-    while ( alive_ && gazebo_ros_->node()->ok() ) {
-        queue_.callAvailable ( ros::WallDuration ( timeout ) );
+    while (alive_ && gazebo_ros_->node()->ok()) {
+        queue_.callAvailable(ros::WallDuration(timeout));
     }
 }
 
 void GazeboRosDiffDrive::UpdateOdometryEncoder()
 {
-    double vl = joints_[LEFT]->GetVelocity ( 0 );
-    double vr = joints_[RIGHT]->GetVelocity ( 0 );
+    double vl = joints_[LEFT]->GetVelocity(0);
+    double vr = joints_[RIGHT]->GetVelocity(0);
 #if GAZEBO_MAJOR_VERSION >= 8
     common::Time current_time = parent->GetWorld()->SimTime();
 #else
     common::Time current_time = parent->GetWorld()->GetSimTime();
 #endif
-    double seconds_since_last_update = ( current_time - last_odom_update_ ).Double();
+    const double seconds_since_last_update = (current_time - last_odom_update_).Double();
     last_odom_update_ = current_time;
 
-    double b = wheel_separation_;
+    const double b = wheel_separation_;
 
     // Book: Sigwart 2011 Autonompus Mobile Robots page:337
-    double sl = vl * ( wheel_diameter_ / 2.0 ) * seconds_since_last_update;
-    double sr = vr * ( wheel_diameter_ / 2.0 ) * seconds_since_last_update;
+    double sl = vl * (wheel_diameter_ / 2.0) * seconds_since_last_update;
+    double sr = vr * (wheel_diameter_ / 2.0) * seconds_since_last_update;
     double ssum = sl + sr;
 
     double sdiff = sr - sl;
 
-    double dx = ( ssum ) /2.0 * cos ( pose_encoder_.theta + ( sdiff ) / ( 2.0*b ) );
-    double dy = ( ssum ) /2.0 * sin ( pose_encoder_.theta + ( sdiff ) / ( 2.0*b ) );
-    double dtheta = ( sdiff ) /b;
+    double dx = (ssum) / 2.0 * cos(pose_encoder_.theta + (sdiff) / (2.0 * b));
+    double dy = (ssum) / 2.0 * sin(pose_encoder_.theta + (sdiff) / (2.0 * b));
+    double dtheta = (sdiff) / b;
 
     pose_encoder_.x += dx;
     pose_encoder_.y += dy;
     pose_encoder_.theta += dtheta;
 
-    double w = dtheta/seconds_since_last_update;
-    double v = sqrt ( dx*dx+dy*dy ) /seconds_since_last_update;
+    double w = dtheta / seconds_since_last_update;
+    double v = sqrt(dx * dx + dy * dy) / seconds_since_last_update;
 
     tf::Quaternion qt;
     tf::Vector3 vt;
-    qt.setRPY ( 0,0,pose_encoder_.theta );
-    vt = tf::Vector3 ( pose_encoder_.x, pose_encoder_.y, 0 );
+    qt.setRPY(0, 0, pose_encoder_.theta);
+    vt = tf::Vector3(pose_encoder_.x, pose_encoder_.y, 0);
 
     odom_.pose.pose.position.x = vt.x();
     odom_.pose.pose.position.y = vt.y();
@@ -385,7 +390,7 @@ void GazeboRosDiffDrive::UpdateOdometryEncoder()
     odom_.pose.pose.orientation.w = qt.w();
 
     odom_.twist.twist.angular.z = w;
-    if (ssum<0) {
+    if (ssum < 0) {
         odom_.twist.twist.linear.x = -v;
     }
     else {
@@ -394,20 +399,23 @@ void GazeboRosDiffDrive::UpdateOdometryEncoder()
     odom_.twist.twist.linear.y = 0;
 }
 
-void GazeboRosDiffDrive::publishOdometry ( double step_time )
+void GazeboRosDiffDrive::publishOdometry(double step_time)
 {
-
     ros::Time current_time = ros::Time::now();
-    std::string odom_frame = gazebo_ros_->resolveTF ( odometry_frame_ );
-    std::string base_footprint_frame = gazebo_ros_->resolveTF ( robot_base_frame_ );
+    std::string odom_frame = gazebo_ros_->resolveTF(odometry_frame_);
+    std::string base_footprint_frame = gazebo_ros_->resolveTF(robot_base_frame_);
 
-    tf::Quaternion qt;
-    tf::Vector3 vt;
+    // Initialize qt and vt to avoid compilation errors
+    tf::Quaternion qt(tf::Quaternion::getIdentity());
+    tf::Vector3 vt = tf::Vector3();
 
     if ( odom_source_ == ENCODER ) {
         // getting data form encoder integration
-        qt = tf::Quaternion ( odom_.pose.pose.orientation.x, odom_.pose.pose.orientation.y, odom_.pose.pose.orientation.z, odom_.pose.pose.orientation.w );
-        vt = tf::Vector3 ( odom_.pose.pose.position.x, odom_.pose.pose.position.y, odom_.pose.pose.position.z );
+        qt = tf::Quaternion(odom_.pose.pose.orientation.x,
+                            odom_.pose.pose.orientation.y,
+                            odom_.pose.pose.orientation.z,
+                            odom_.pose.pose.orientation.w);
+        vt = tf::Vector3(odom_.pose.pose.position.x, odom_.pose.pose.position.y, odom_.pose.pose.position.z);
     }
     if ( odom_source_ == WORLD ) {
         // getting data from gazebo world
@@ -416,8 +424,8 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 #else
         ignition::math::Pose3d pose = parent->GetWorldPose().Ign();
 #endif
-        qt = tf::Quaternion ( pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W() );
-        vt = tf::Vector3 ( pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z() );
+        qt = tf::Quaternion(pose.Rot().X(), pose.Rot().Y(), pose.Rot().Z(), pose.Rot().W());
+        vt = tf::Vector3(pose.Pos().X(), pose.Pos().Y(), pose.Pos().Z());
 
         odom_.pose.pose.position.x = vt.x();
         odom_.pose.pose.position.y = vt.y();
@@ -440,17 +448,16 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
 
         // convert velocity to child_frame_id (aka base_footprint)
         float yaw = pose.Rot().Yaw();
-        odom_.twist.twist.linear.x = cosf ( yaw ) * linear.X() + sinf ( yaw ) * linear.Y();
-        odom_.twist.twist.linear.y = cosf ( yaw ) * linear.Y() - sinf ( yaw ) * linear.X();
+        odom_.twist.twist.linear.x = cosf(yaw) * linear.X() + sinf(yaw) * linear.Y();
+        odom_.twist.twist.linear.y = cosf(yaw) * linear.Y() - sinf(yaw) * linear.X();
     }
 
     if (publishOdomTF_ == true){
-        tf::Transform base_footprint_to_odom ( qt, vt );
-        transform_broadcaster_->sendTransform (
-            tf::StampedTransform ( base_footprint_to_odom, current_time,
-                                   odom_frame, base_footprint_frame ) );
+        tf::Transform base_footprint_to_odom(qt, vt);
+        transform_broadcaster_->sendTransform(
+            tf::StampedTransform(base_footprint_to_odom, current_time,
+                                 odom_frame, base_footprint_frame));
     }
-
 
     // set covariance
     odom_.pose.covariance[0] = 0.00001;
@@ -460,14 +467,13 @@ void GazeboRosDiffDrive::publishOdometry ( double step_time )
     odom_.pose.covariance[28] = 1000000000000.0;
     odom_.pose.covariance[35] = 0.001;
 
-
     // set header
     odom_.header.stamp = current_time;
     odom_.header.frame_id = odom_frame;
     odom_.child_frame_id = base_footprint_frame;
 
-    odometry_publisher_.publish ( odom_ );
+    odometry_publisher_.publish(odom_);
 }
 
-GZ_REGISTER_MODEL_PLUGIN ( GazeboRosDiffDrive )
-}
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosDiffDrive)
+}  // namespace gazebo


### PR DESCRIPTION
# Description

`/odom` topic doesn't publish negative velocities when moving backward. This PR creates a copy of that plugin to introduce the fix: [https://github.com/ros-simulation/gazebo_ros_pkgs/pull/976](https://github.com/ros-simulation/gazebo_ros_pkgs/pull/976)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
# Run RViz
RVIZ=true GUI=false roslaunch ca_gazebo create_empty_world.launch
# Move the robot with teleop
roslaunch ca_tools keyboard_teleop.launch
```

**Test Configuration**:

- [X] Gazebo simulation

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
