### PR TITLE
Fix path to roomba.rules in create_rules.sh

### DIFF
--- a/ca_bringup/scripts/udev/create_rules.sh
+++ b/ca_bringup/scripts/udev/create_rules.sh
@@ -38,7 +38,7 @@ echo "remap the device serial port(ttyUSBX) to /dev/roomba"
 echo "roomba usb connection as /dev/roomba, check it using the command: ls -l /dev | grep ttyUSB"
 echo "start copy roomba.rules to /etc/udev/rules.d/"
 echo "roomba.rules"
-sudo cp `rospack find ca_bringup`/scripts/roomba.rules /etc/udev/rules.d
+sudo cp `rospack find ca_bringup`/scripts/rules/roomba.rules /etc/udev/rules.d
 
 echo "remap the device serial port(ttyUSBX) to  rplidar"
 echo "rplidar usb connection as /dev/rplidar, check it using the command: ls -l /dev | grep ttyUSB"


### PR DESCRIPTION
The create_rules.sh script had the incorrect path to roomba.rules file in ca_bringup. Simple correction. 