### PR TITLE
Add robot + battery namespace

### DIFF
--- a/ca_description/urdf/create_base.xacro
+++ b/ca_description/urdf/create_base.xacro
@@ -95,6 +95,7 @@
     </xacro:caster_wheel>
 
     <xacro:battery_sensor
+        namespace="${robot_name}"
         voltage="14.4"
         capacity_ah="4.5"
         charge_current="0.2"

--- a/ca_description/urdf/create_battery.xacro
+++ b/ca_description/urdf/create_battery.xacro
@@ -2,7 +2,7 @@
 <robot xmlns:xacro="http://ros.org/wiki/xacro">
 
 <xacro:macro name="battery_sensor"
-             params="name:=battery parent:=base_footprint
+             params="name:=battery parent:=base_footprint namespace:=create
                      voltage capacity_ah charge_current discharge_current
                      *origin">
 
@@ -39,8 +39,6 @@
   <joint name="${name}_dummy_joint" type="continuous">
     <parent link="${parent_link}"/>
     <child link="${dummy_link}"/>
-    <!-- <limit effort="10" velocity="10" /> -->
-    <!-- <dynamics damping="0.1" friction="1000.0"/> -->
   </joint>
 
   <link name="${dummy_link}">
@@ -59,7 +57,7 @@
 
   <gazebo>
     <plugin name="battery_discharge" filename="libbattery_discharge.so">
-      <ros_node>${name}</ros_node>
+      <ros_node>${namespace}</ros_node>
       <link_name>${dummy_link}</link_name>
       <battery_name>${name}</battery_name>
       <constant_coef>${voltage}</constant_coef>


### PR DESCRIPTION
# Description

This PR adds a namespace composed of robot_name + battery_name for the topics and services of the battery plugin.

It's related to [this PR](https://github.com/RoboticaUtnFrba/brass_gazebo_battery/pull/1).

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

```bash
GUI=false roslaunch ca_gazebo create_empty_world..launch
```

**Test Configuration**:

- [ ] Real robot
- [X] Gazebo simulation

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
