### PR TITLE
Add support for Realsense D435

### DIFF
--- a/ca_bringup/launch/minimal.launch
+++ b/ca_bringup/launch/minimal.launch
@@ -42,6 +42,7 @@
 
     <!-- Mapping sensors -->
     <include if="$(eval arg('laser')=='astra')"     file="$(find ca_camera)/launch/orbbec_astra_pro.launch"/>
+    <include if="$(eval arg('laser')=='d435')"      file="$(find ca_camera)/launch/d435.launch"/>
     <include if="$(eval arg('laser')=='kinect')"    file=""/>
     <include if="$(eval arg('laser')=='r200')"      file="$(find ca_camera)/launch/realsense_r200.launch"/>
     <include if="$(eval arg('laser')=='rplidar')"   file="$(find ca_camera)/launch/rplidar_a2.launch"/>

--- a/ca_description/package.xml
+++ b/ca_description/package.xml
@@ -19,6 +19,7 @@
 
   <exec_depend>controller_manager</exec_depend>
   <exec_depend>joint_state_publisher</exec_depend>
+  <exec_depend>realsense2_description</exec_depend>
   <exec_depend>robot_state_publisher</exec_depend>
   <exec_depend>tf</exec_depend>
   <exec_depend>urdf</exec_depend>

--- a/ca_description/urdf/sensors/lasers/calibration.yaml
+++ b/ca_description/urdf/sensors/lasers/calibration.yaml
@@ -6,6 +6,14 @@ astra:
     xyz: [0, 0, 0]
     rpy: [0, 0, 0]
 
+d435:
+  rgb:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+  depth:
+    xyz: [0, 0, 0]
+    rpy: [0, 0, 0]
+
 kinect:
   rgb:
     xyz: [0, 0, 0]

--- a/ca_description/urdf/sensors/lasers/d435.xacro
+++ b/ca_description/urdf/sensors/lasers/d435.xacro
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<robot xmlns:xacro="http://ros.org/wiki/xacro">
+
+<xacro:include filename="$(find ca_description)/urdf/sensors/lasers/calibration.xacro"/>
+<xacro:include filename="$(find ca_description)/urdf/sensors/lasers/sim_3d_sensor.xacro"/>
+<xacro:include filename="$(find realsense2_description)/urdf/_d435.urdf.xacro"/>
+
+<!-- Intel Realsense D435 -->
+<xacro:property name="name"   value="d435"/>
+<xacro:property name="parent" value="base_link"/>
+
+<xacro:arg name="add_plug" default="false"/>
+
+<xacro:sensor_d435 parent="${parent}" use_nominal_extrinsics="false">
+  <origin xyz="${laser_origin}"/>
+</xacro:sensor_d435>
+
+<!-- <xacro:sim_3d_sensor name="${name}" color="Gazebo/FlatBlack"/> -->
+
+</robot>

--- a/ca_description/urdf/sensors/lasers/poses.yaml
+++ b/ca_description/urdf/sensors/lasers/poses.yaml
@@ -1,11 +1,13 @@
 roomblock:
   astra: 0 0 0.19
+  d435: 0 0 0.19
   kinect: 0.025 -0.01 0.21
   r200: 0 0 0.172
   rplidar: 0 0 0.16
   xtion_pro: 0.015 0.018 0.181
 turtlebot:
   astra: 0.1 0 0.245
+  d435: 0.11 0 0.2125
   kinect: 0.025 -0.01 0.257
   r200: 0.125 0 0.22
   rplidar: 0 0 0.21

--- a/dependencies.txt
+++ b/dependencies.txt
@@ -22,6 +22,8 @@ ros-*-map-server
 ros-*-move-base
 ros-*-move-base-flex
 ros-*-openni2-launch
+ros-*-realsense2-camera
+ros-*-realsense2-description
 ros-*-robot-localization
 ros-*-rplidar-ros
 ros-*-sbpl-lattice-planner

--- a/docker/create_ros_melodic_gazebo9/Dockerfile
+++ b/docker/create_ros_melodic_gazebo9/Dockerfile
@@ -50,6 +50,11 @@ ENV CI=true
 RUN /bin/bash ${IMU_SCRIPT}
 RUN rm -r ${IMU_SCRIPT}
 
+# Install the latest Intel® RealSense™ SDK 2.0
+RUN apt-key adv --keyserver keys.gnupg.net --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE || apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-key F6E65AC044F831AC80A06380C8B3A55A6F3EFCDE
+RUN add-apt-repository "deb http://realsense-hw-public.s3.amazonaws.com/Debian/apt-repo $(lsb_release -sc) main" -u
+RUN apt-get install -y librealsense2-dkms librealsense2-utils librealsense2-dev
+
 # Install dependencies with vcs
 # http://wiki.ros.org/catkin/Tutorials/using_a_workspace#Installing_Packages
 ENV DEPS_WS=/deps_ws

--- a/docker/run
+++ b/docker/run
@@ -41,6 +41,16 @@ def run_dev_environment(command, ros="melodic", gazebo="9"):
     # USB devices for the real robot
     docker_args.append(ut.mount_resource("/dev/roomba"))
     docker_args.append(ut.mount_resource("/dev/rplidar"))
+    docker_args.append(ut.mount_resource("/dev/video0"))
+    docker_args.append(ut.mount_resource("/dev/video1"))
+    docker_args.append(ut.mount_resource("/dev/video2"))
+    docker_args.append(ut.mount_resource("/dev/video3"))
+    docker_args.append(ut.mount_resource("/dev/video4"))
+    docker_args.append(ut.mount_resource("/dev/video5"))
+    docker_args.append(ut.mount_resource("/dev/video6"))
+    docker_args.append(ut.mount_resource("/dev/video7"))
+    docker_args.append(ut.mount_resource("/dev/video8"))
+    docker_args.append(ut.mount_resource("/dev/video9"))
 
     # To allow installing packages
     docker_args.append("--group-add=sudo")

--- a/sensors/ca_camera/CMakeLists.txt
+++ b/sensors/ca_camera/CMakeLists.txt
@@ -5,6 +5,7 @@ find_package(catkin REQUIRED COMPONENTS
   astra_camera
   camera_calibration
   openni2_launch
+  realsense2_camera
 	rplidar_ros
 )
 

--- a/sensors/ca_camera/launch/d435.launch
+++ b/sensors/ca_camera/launch/d435.launch
@@ -1,0 +1,10 @@
+<launch>
+  <arg name="robot_id"  default="$(optenv ID 1)"      doc="Unique identifier of the robot [1-Inf.)"/>
+  <arg name="ns"        value="create$(arg robot_id)" doc="Namespace of the robot. By default: create1"/>
+  <arg name="tf_prefix" value="$(arg ns)_tf"          doc="Tf prefix"/>
+
+  <include file="$(find realsense2_camera)/launch/rs_camera.launch">
+    <arg name="camera" value="d435"/>
+    <arg name="publish_odom_tf" value="false"/>
+  </include>
+</launch>

--- a/sensors/ca_camera/package.xml
+++ b/sensors/ca_camera/package.xml
@@ -13,6 +13,7 @@
   <depend>astra_camera</depend>
   <depend>camera_calibration</depend>
   <depend>openni2_launch</depend>
+  <depend>realsense2_camera</depend>
   <depend>rplidar_ros</depend>
 
 </package>


### PR DESCRIPTION
# Description

This PR adds support for Realsense D435 based on [this tutorial](https://github.com/RoboticaUtnFrba/create_autonomy/wiki/Add-new-sensor).

Fixes #223.

## Type of change

- [X] New feature (non-breaking change which adds functionality)
- [X] This change requires a documentation update

# How Has This Been Tested?

```bash
# Simulation
LASER=d435 RVIZ=true roslaunch ca_gazebo create_empty_world.launch
# Real robot
LASER=d435 roslaunch ca_bringup minimal.launch
```

**Test Configuration**:

- [X] Real robot
- [X] Gazebo simulation

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
