### PR TITLE
Add IMU plugin with Tf prefix for frame ID

### DIFF
--- a/ca_description/urdf/create_base_gazebo.xacro
+++ b/ca_description/urdf/create_base_gazebo.xacro
@@ -70,7 +70,6 @@
         <contact>
           <collision>bumper_link_collision</collision>
         </contact>
-        <!-- Plugin -->
         <plugin name="create_bumper_controller" filename="libcreate_bumper_plugin.so">
           <frameName>base_footprint</frameName>
           <robotNamespace>${robot_name}</robotNamespace>

--- a/ca_description/urdf/sensors/imu_sensor.xacro
+++ b/ca_description/urdf/sensors/imu_sensor.xacro
@@ -28,17 +28,17 @@
   </gazebo>
 
   <gazebo>
-    <plugin name="${name}" filename="libgazebo_ros_imu.so">
+    <plugin name="${name}" filename="libcreate_imu_plugin.so">
       <alwaysOn>true</alwaysOn>
+      <rosDebugLevel>na</rosDebugLevel>
       <updateRate>40</updateRate>
-      <robotNamespace>create1</robotNamespace>
       <bodyName>${link_name}</bodyName>
-      <frameName>create1_tf/${link_name}</frameName>
+      <frameName>${link_name}</frameName>
       <topicName>${name}/data</topicName>
       <serviceName>${name}/is_calibrated</serviceName>
       <gaussianNoise>${0.0017*0.0017}</gaussianNoise>
-      <xyzOffsets>0 0 0</xyzOffsets>
-      <rpyOffsets>0 0 0</rpyOffsets>
+      <xyzOffset>0 0 0</xyzOffset>
+      <rpyOffset>0 0 0</rpyOffset>
     </plugin>
   </gazebo>
 

--- a/ca_gazebo/CMakeLists.txt
+++ b/ca_gazebo/CMakeLists.txt
@@ -37,6 +37,7 @@ set(PLUGIN_LIST
   create_bumper_plugin
   create_cliff_plugin
   create_diff_drive
+  create_imu_plugin
   create_virtual_wall_plugin
   model_pose_publisher_plugin
   traffic_light_plugin

--- a/ca_gazebo/include/ca_gazebo/create_imu_plugin.h
+++ b/ca_gazebo/include/ca_gazebo/create_imu_plugin.h
@@ -14,8 +14,8 @@
  * limitations under the License.
  *
 */
-#ifndef GAZEBO_ROS_IMU_HH
-#define GAZEBO_ROS_IMU_HH
+#ifndef CA_GAZEBO_CREATE_IMU_PLUGIN_H
+#define CA_GAZEBO_CREATE_IMU_PLUGIN_H
 
 #include <string>
 #include <boost/thread.hpp>
@@ -37,95 +37,97 @@
 
 namespace gazebo
 {
-  class GazeboRosCreateIMU : public ModelPlugin
-  {
-    /// \brief Constructor
-    public: GazeboRosCreateIMU();
+class GazeboRosCreateIMU : public ModelPlugin
+{
+public:
+  /// \brief Constructor
+  GazeboRosCreateIMU();
 
-    /// \brief Destructor
-    public: virtual ~GazeboRosCreateIMU();
+  /// \brief Destructor
+  virtual ~GazeboRosCreateIMU();
 
-    /// \brief Load the controller
-    /// \param node XML config node
-    public: void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+  /// \brief Load the controller
+  /// \param node XML config node
+  void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
 
-    /// \brief Update the controller
-    protected: virtual void UpdateChild();
+protected:
+  /// \brief Update the controller
+  virtual void UpdateChild();
+private:
+  /// \brief The parent World
+  physics::WorldPtr world_;
 
-    /// \brief The parent World
-    private: physics::WorldPtr world_;
+  /// \brief The parent Model
+  physics::ModelPtr model_;
 
-    /// \brief The parent Model
-    private: physics::ModelPtr model_;
+  /// \brief The link referred to by this plugin
+  physics::LinkPtr link;
 
-    /// \brief The link referred to by this plugin
-    private: physics::LinkPtr link;
+  /// \brief pointer to gazebo ros node
+  GazeboRosPtr gazebo_ros_;
+  ros::Publisher pub_;
+  PubQueue<sensor_msgs::Imu>::Ptr pub_Queue;
 
-    /// \brief pointer to gazebo ros node
-    GazeboRosPtr gazebo_ros_;
-    private: ros::Publisher pub_;
-    private: PubQueue<sensor_msgs::Imu>::Ptr pub_Queue;
+  /// \brief ros message
+  sensor_msgs::Imu imu_msg_;
 
-    /// \brief ros message
-    private: sensor_msgs::Imu imu_msg_;
+  /// \brief store link name
+  std::string link_name_;
 
-    /// \brief store link name
-    private: std::string link_name_;
+  /// \brief store frame name
+  std::string frame_name_;
 
-    /// \brief store frame name
-    private: std::string frame_name_;
+  /// \brief topic name
+  std::string topic_name_;
 
-    /// \brief topic name
-    private: std::string topic_name_;
+  /// \brief allow specifying constant xyz and rpy offsets
+  ignition::math::Pose3d offset_;
 
-    /// \brief allow specifying constant xyz and rpy offsets
-    private: ignition::math::Pose3d offset_;
+  /// \brief A mutex to lock access to fields
+  /// that are used in message callbacks
+  boost::mutex lock_;
 
-    /// \brief A mutex to lock access to fields
-    /// that are used in message callbacks
-    private: boost::mutex lock_;
+  /// \brief save last_time
+  common::Time last_time_;
+  ignition::math::Vector3d last_vpos_;
+  ignition::math::Vector3d last_veul_;
+  ignition::math::Vector3d apos_;
+  ignition::math::Vector3d aeul_;
 
-    /// \brief save last_time
-    private: common::Time last_time_;
-    private: ignition::math::Vector3d last_vpos_;
-    private: ignition::math::Vector3d last_veul_;
-    private: ignition::math::Vector3d apos_;
-    private: ignition::math::Vector3d aeul_;
+  // rate control
+  double update_rate_;
 
-    // rate control
-    private: double update_rate_;
+  /// \brief: keep initial pose to offset orientation in imu message
+  ignition::math::Pose3d initial_pose_;
 
-    /// \brief: keep initial pose to offset orientation in imu message
-    private: ignition::math::Pose3d initial_pose_;
+  /// \brief Gaussian noise
+  double gaussian_noise_;
 
-    /// \brief Gaussian noise
-    private: double gaussian_noise_;
+  /// \brief Gaussian noise generator
+  double GaussianKernel(double mu, double sigma);
 
-    /// \brief Gaussian noise generator
-    private: double GaussianKernel(double mu, double sigma);
+  /// \brief call back when using service
+  bool ServiceCallback(const std_srvs::Empty::Request &req,
+                        const std_srvs::Empty::Response &res);
 
-    /// \brief call back when using service
-    private: bool ServiceCallback(std_srvs::Empty::Request &req,
-                                  std_srvs::Empty::Response &res);
+  ros::ServiceServer srv_;
+  std::string service_name_;
 
-    private: ros::ServiceServer srv_;
-    private: std::string service_name_;
+  ros::CallbackQueue imu_queue_;
+  void IMUQueueThread();
+  boost::thread callback_queue_thread_;
 
-    private: ros::CallbackQueue imu_queue_;
-    private: void IMUQueueThread();
-    private: boost::thread callback_queue_thread_;
+  // Pointer to the update event connection
+  event::ConnectionPtr update_connection_;
 
-    // Pointer to the update event connection
-    private: event::ConnectionPtr update_connection_;
+  // deferred load in case ros is blocking
+  sdf::ElementPtr sdf_;
+  void LoadThread();
+  boost::thread deferred_load_thread_;
+  unsigned int seed;
 
-    // deferred load in case ros is blocking
-    private: sdf::ElementPtr sdf_;
-    private: void LoadThread();
-    private: boost::thread deferred_load_thread_;
-    private: unsigned int seed;
-
-    // ros publish multi queue, prevents publish() blocking
-    private: PubMultiQueue pmq;
-  };
-}
-#endif
+  // ros publish multi queue, prevents publish() blocking
+  PubMultiQueue pmq;
+};
+}  // namespace gazebo
+#endif  // CA_GAZEBO_CREATE_IMU_PLUGIN_H

--- a/ca_gazebo/include/ca_gazebo/create_imu_plugin.h
+++ b/ca_gazebo/include/ca_gazebo/create_imu_plugin.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright 2012 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+#ifndef GAZEBO_ROS_IMU_HH
+#define GAZEBO_ROS_IMU_HH
+
+#include <string>
+#include <boost/thread.hpp>
+#include <boost/thread/mutex.hpp>
+#include <boost/bind.hpp>
+
+#include <ros/ros.h>
+#include <ros/callback_queue.h>
+#include <ros/advertise_options.h>
+#include <sensor_msgs/Imu.h>
+#include <std_srvs/Empty.h>
+
+#include <gazebo/common/common.hh>
+#include <gazebo/physics/physics.hh>
+#include <gazebo/transport/transport.hh>
+
+#include <gazebo_plugins/gazebo_ros_utils.h>
+#include <gazebo_plugins/PubQueue.h>
+
+namespace gazebo
+{
+  class GazeboRosCreateIMU : public ModelPlugin
+  {
+    /// \brief Constructor
+    public: GazeboRosCreateIMU();
+
+    /// \brief Destructor
+    public: virtual ~GazeboRosCreateIMU();
+
+    /// \brief Load the controller
+    /// \param node XML config node
+    public: void Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf);
+
+    /// \brief Update the controller
+    protected: virtual void UpdateChild();
+
+    /// \brief The parent World
+    private: physics::WorldPtr world_;
+
+    /// \brief The parent Model
+    private: physics::ModelPtr model_;
+
+    /// \brief The link referred to by this plugin
+    private: physics::LinkPtr link;
+
+    /// \brief pointer to gazebo ros node
+    GazeboRosPtr gazebo_ros_;
+    private: ros::Publisher pub_;
+    private: PubQueue<sensor_msgs::Imu>::Ptr pub_Queue;
+
+    /// \brief ros message
+    private: sensor_msgs::Imu imu_msg_;
+
+    /// \brief store link name
+    private: std::string link_name_;
+
+    /// \brief store frame name
+    private: std::string frame_name_;
+
+    /// \brief topic name
+    private: std::string topic_name_;
+
+    /// \brief allow specifying constant xyz and rpy offsets
+    private: ignition::math::Pose3d offset_;
+
+    /// \brief A mutex to lock access to fields
+    /// that are used in message callbacks
+    private: boost::mutex lock_;
+
+    /// \brief save last_time
+    private: common::Time last_time_;
+    private: ignition::math::Vector3d last_vpos_;
+    private: ignition::math::Vector3d last_veul_;
+    private: ignition::math::Vector3d apos_;
+    private: ignition::math::Vector3d aeul_;
+
+    // rate control
+    private: double update_rate_;
+
+    /// \brief: keep initial pose to offset orientation in imu message
+    private: ignition::math::Pose3d initial_pose_;
+
+    /// \brief Gaussian noise
+    private: double gaussian_noise_;
+
+    /// \brief Gaussian noise generator
+    private: double GaussianKernel(double mu, double sigma);
+
+    /// \brief call back when using service
+    private: bool ServiceCallback(std_srvs::Empty::Request &req,
+                                  std_srvs::Empty::Response &res);
+
+    private: ros::ServiceServer srv_;
+    private: std::string service_name_;
+
+    private: ros::CallbackQueue imu_queue_;
+    private: void IMUQueueThread();
+    private: boost::thread callback_queue_thread_;
+
+    // Pointer to the update event connection
+    private: event::ConnectionPtr update_connection_;
+
+    // deferred load in case ros is blocking
+    private: sdf::ElementPtr sdf_;
+    private: void LoadThread();
+    private: boost::thread deferred_load_thread_;
+    private: unsigned int seed;
+
+    // ros publish multi queue, prevents publish() blocking
+    private: PubMultiQueue pmq;
+  };
+}
+#endif

--- a/ca_gazebo/src/create_imu_plugin.cpp
+++ b/ca_gazebo/src/create_imu_plugin.cpp
@@ -1,0 +1,313 @@
+/*
+ * Copyright 2013 Open Source Robotics Foundation
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ *
+*/
+/*
+ * Desc: 3D position interface for ground truth.
+ * Author: Sachin Chitta and John Hsu
+ * Date: 1 June 2008
+ */
+
+#include <ca_gazebo/create_imu_plugin.h>
+
+namespace gazebo
+{
+// Register this plugin with the simulator
+GZ_REGISTER_MODEL_PLUGIN(GazeboRosCreateIMU)
+
+////////////////////////////////////////////////////////////////////////////////
+// Constructor
+GazeboRosCreateIMU::GazeboRosCreateIMU()
+{
+  this->seed = 0;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Destructor
+GazeboRosCreateIMU::~GazeboRosCreateIMU()
+{
+  this->update_connection_.reset();
+  // Finalize the controller
+  this->gazebo_ros_->node()->shutdown();
+  this->callback_queue_thread_.join();
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosCreateIMU::Load(physics::ModelPtr _parent, sdf::ElementPtr _sdf)
+{
+  // save pointers
+  this->model_ = _parent;
+  this->world_ = this->model_->GetWorld();
+  this->sdf_ = _sdf;
+
+  // ros callback queue for processing subscription
+  this->deferred_load_thread_ = boost::thread(
+    boost::bind(&GazeboRosCreateIMU::LoadThread, this));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Load the controller
+void GazeboRosCreateIMU::LoadThread()
+{
+  this->gazebo_ros_ = GazeboRosPtr ( new GazeboRos ( this->model_, this->sdf_, "Imu" ) );
+  // Make sure the ROS node for Gazebo has already been initialized
+  this->gazebo_ros_->isInitialized();
+
+  this->gazebo_ros_->getParameter<std::string> (this->service_name_, "serviceName", "/default_imu");
+  this->gazebo_ros_->getParameter<std::string> (this->topic_name_, "topicName", "/default_imu");
+  this->gazebo_ros_->getParameter<double> (this->gaussian_noise_, "gaussianNoise", 0.0);
+  this->gazebo_ros_->getParameter<std::string> (this->link_name_ , "bodyName", "");
+  ignition::math::Vector3d xyzOffset, rpyOffset;
+  this->gazebo_ros_->getParameter<ignition::math::Vector3d>
+      (xyzOffset, "xyzOffset", ignition::math::Vector3d(0, 0, 0));
+  this->offset_.Pos() = xyzOffset;
+  this->gazebo_ros_->getParameter<ignition::math::Vector3d>
+      (rpyOffset, "rpyOffset", ignition::math::Vector3d(0, 0, 0));
+  this->offset_.Rot() = ignition::math::Quaterniond(rpyOffset);
+  this->gazebo_ros_->getParameter<double> (this->update_rate_, "updateRate", 0.0);
+  std::string frame;
+  this->gazebo_ros_->getParameter<std::string> (frame, "frameName", "");
+  this->frame_name_ = this->gazebo_ros_->resolveTF(frame);
+
+  // publish multi queue
+  this->pmq.startServiceThread();
+
+  // assert that the body by link_name_ exists
+  this->link = boost::dynamic_pointer_cast<physics::Link>(
+#if GAZEBO_MAJOR_VERSION >= 8
+    this->world_->EntityByName(this->link_name_));
+#else
+    this->world_->GetEntity(this->link_name_));
+#endif
+  if (!this->link)
+  {
+    ROS_FATAL_NAMED("imu", "gazebo_ros_imu plugin error: bodyName: %s does not exist\n",
+      this->link_name_.c_str());
+    return;
+  }
+
+  // if topic name specified as empty, do not publish
+  if (this->topic_name_ != "")
+  {
+    this->pub_Queue = this->pmq.addPub<sensor_msgs::Imu>();
+    this->pub_ = this->gazebo_ros_->node()->advertise<sensor_msgs::Imu>(
+      this->topic_name_, 1);
+
+    // advertise services on the custom queue
+    ros::AdvertiseServiceOptions aso =
+      ros::AdvertiseServiceOptions::create<std_srvs::Empty>(
+      this->service_name_, boost::bind(&GazeboRosCreateIMU::ServiceCallback,
+      this, _1, _2), ros::VoidPtr(), &this->imu_queue_);
+    this->srv_ = this->gazebo_ros_->node()->advertiseService(aso);
+  }
+
+  // Initialize the controller
+#if GAZEBO_MAJOR_VERSION >= 8
+  this->last_time_ = this->world_->SimTime();
+#else
+  this->last_time_ = this->world_->GetSimTime();
+#endif
+
+  // this->initial_pose_ = this->link->GetPose();
+#if GAZEBO_MAJOR_VERSION >= 8
+  this->last_vpos_ = this->link->WorldLinearVel();
+  this->last_veul_ = this->link->WorldAngularVel();
+#else
+  this->last_vpos_ = this->link->GetWorldLinearVel().Ign();
+  this->last_veul_ = this->link->GetWorldAngularVel().Ign();
+#endif
+  this->apos_ = 0;
+  this->aeul_ = 0;
+
+  // start custom queue for imu
+  this->callback_queue_thread_ =
+    boost::thread(boost::bind(&GazeboRosCreateIMU::IMUQueueThread, this));
+
+
+  // New Mechanism for Updating every World Cycle
+  // Listen to the update event. This event is broadcast every
+  // simulation iteration.
+  this->update_connection_ = event::Events::ConnectWorldUpdateBegin(
+      boost::bind(&GazeboRosCreateIMU::UpdateChild, this));
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// returns true always, imu is always calibrated in sim
+bool GazeboRosCreateIMU::ServiceCallback(std_srvs::Empty::Request &req,
+                                        std_srvs::Empty::Response &res)
+{
+  return true;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Update the controller
+void GazeboRosCreateIMU::UpdateChild()
+{
+#if GAZEBO_MAJOR_VERSION >= 8
+  common::Time cur_time = this->world_->SimTime();
+#else
+  common::Time cur_time = this->world_->GetSimTime();
+#endif
+
+  // rate control
+  if (this->update_rate_ > 0 &&
+      (cur_time - this->last_time_).Double() < (1.0 / this->update_rate_))
+    return;
+
+  if ((this->pub_.getNumSubscribers() > 0 && this->topic_name_ != ""))
+  {
+    ignition::math::Pose3d pose;
+    ignition::math::Quaterniond rot;
+    ignition::math::Vector3d pos;
+
+    // Get Pose/Orientation ///@todo: verify correctness
+#if GAZEBO_MAJOR_VERSION >= 8
+    pose = this->link->WorldPose();
+#else
+    pose = this->link->GetWorldPose().Ign();
+#endif
+    // apply xyz offsets and get position and rotation components
+    pos = pose.Pos() + this->offset_.Pos();
+    rot = pose.Rot();
+
+    // apply rpy offsets
+    rot = this->offset_.Rot()*rot;
+    rot.Normalize();
+
+    // get Rates
+#if GAZEBO_MAJOR_VERSION >= 8
+    ignition::math::Vector3d vpos = this->link->WorldLinearVel();
+    ignition::math::Vector3d veul = this->link->WorldAngularVel();
+#else
+    ignition::math::Vector3d vpos = this->link->GetWorldLinearVel().Ign();
+    ignition::math::Vector3d veul = this->link->GetWorldAngularVel().Ign();
+#endif
+
+    // differentiate to get accelerations
+    double tmp_dt = this->last_time_.Double() - cur_time.Double();
+    if (tmp_dt != 0)
+    {
+      this->apos_ = (this->last_vpos_ - vpos) / tmp_dt;
+      this->aeul_ = (this->last_veul_ - veul) / tmp_dt;
+      this->last_vpos_ = vpos;
+      this->last_veul_ = veul;
+    }
+
+    // copy data into pose message
+    this->imu_msg_.header.frame_id = this->frame_name_;
+    this->imu_msg_.header.stamp.sec = cur_time.sec;
+    this->imu_msg_.header.stamp.nsec = cur_time.nsec;
+
+    // orientation quaternion
+
+    // uncomment this if we are reporting orientation in the local frame
+    // not the case for our imu definition
+    // // apply fixed orientation offsets of initial pose
+    // rot = this->initial_pose_.Rot()*rot;
+    // rot.Normalize();
+
+    this->imu_msg_.orientation.x = rot.X();
+    this->imu_msg_.orientation.y = rot.Y();
+    this->imu_msg_.orientation.z = rot.Z();
+    this->imu_msg_.orientation.w = rot.W();
+
+    // pass euler angular rates
+    ignition::math::Vector3d linear_velocity(
+      veul.X() + this->GaussianKernel(0, this->gaussian_noise_),
+      veul.Y() + this->GaussianKernel(0, this->gaussian_noise_),
+      veul.Z() + this->GaussianKernel(0, this->gaussian_noise_));
+    // rotate into local frame
+    // @todo: deal with offsets!
+    linear_velocity = rot.RotateVector(linear_velocity);
+    this->imu_msg_.angular_velocity.x    = linear_velocity.X();
+    this->imu_msg_.angular_velocity.y    = linear_velocity.Y();
+    this->imu_msg_.angular_velocity.z    = linear_velocity.Z();
+
+    // pass accelerations
+    ignition::math::Vector3d linear_acceleration(
+      apos_.X() + this->GaussianKernel(0, this->gaussian_noise_),
+      apos_.Y() + this->GaussianKernel(0, this->gaussian_noise_),
+      apos_.Z() + this->GaussianKernel(0, this->gaussian_noise_));
+    // rotate into local frame
+    // @todo: deal with offsets!
+    linear_acceleration = rot.RotateVector(linear_acceleration);
+    this->imu_msg_.linear_acceleration.x    = linear_acceleration.X();
+    this->imu_msg_.linear_acceleration.y    = linear_acceleration.Y();
+    this->imu_msg_.linear_acceleration.z    = linear_acceleration.Z();
+
+    // fill in covariance matrix
+    /// @todo: let user set separate linear and angular covariance values.
+    /// @todo: apply appropriate rotations from frame_pose
+    double gn2 = this->gaussian_noise_*this->gaussian_noise_;
+    this->imu_msg_.orientation_covariance[0] = gn2;
+    this->imu_msg_.orientation_covariance[4] = gn2;
+    this->imu_msg_.orientation_covariance[8] = gn2;
+    this->imu_msg_.angular_velocity_covariance[0] = gn2;
+    this->imu_msg_.angular_velocity_covariance[4] = gn2;
+    this->imu_msg_.angular_velocity_covariance[8] = gn2;
+    this->imu_msg_.linear_acceleration_covariance[0] = gn2;
+    this->imu_msg_.linear_acceleration_covariance[4] = gn2;
+    this->imu_msg_.linear_acceleration_covariance[8] = gn2;
+
+    {
+      boost::mutex::scoped_lock lock(this->lock_);
+      // publish to ros
+      if (this->pub_.getNumSubscribers() > 0 && this->topic_name_ != "")
+          this->pub_Queue->push(this->imu_msg_, this->pub_);
+    }
+
+    // save last time stamp
+    this->last_time_ = cur_time;
+  }
+}
+
+
+//////////////////////////////////////////////////////////////////////////////
+// Utility for adding noise
+double GazeboRosCreateIMU::GaussianKernel(double mu, double sigma)
+{
+  // using Box-Muller transform to generate two independent standard
+  // normally disbributed normal variables see wikipedia
+
+  // normalized uniform random variable
+  double U = static_cast<double>(rand_r(&this->seed)) /
+             static_cast<double>(RAND_MAX);
+
+  // normalized uniform random variable
+  double V = static_cast<double>(rand_r(&this->seed)) /
+             static_cast<double>(RAND_MAX);
+
+  double X = sqrt(-2.0 * ::log(U)) * cos(2.0*M_PI * V);
+  // double Y = sqrt(-2.0 * ::log(U)) * sin(2.0*M_PI * V);
+
+  // there are 2 indep. vars, we'll just use X
+  // scale to our mu and sigma
+  X = sigma * X + mu;
+  return X;
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// Put laser data to the interface
+void GazeboRosCreateIMU::IMUQueueThread()
+{
+  static const double timeout = 0.01;
+
+  while (gazebo_ros_->node()->ok())
+  {
+    this->imu_queue_.callAvailable(ros::WallDuration(timeout));
+  }
+}
+}

--- a/ca_gazebo/src/create_imu_plugin.cpp
+++ b/ca_gazebo/src/create_imu_plugin.cpp
@@ -20,6 +20,8 @@
  * Date: 1 June 2008
  */
 
+#include <string>
+
 #include <ca_gazebo/create_imu_plugin.h>
 
 namespace gazebo
@@ -146,8 +148,8 @@ void GazeboRosCreateIMU::LoadThread()
 
 ////////////////////////////////////////////////////////////////////////////////
 // returns true always, imu is always calibrated in sim
-bool GazeboRosCreateIMU::ServiceCallback(std_srvs::Empty::Request &req,
-                                        std_srvs::Empty::Response &res)
+bool GazeboRosCreateIMU::ServiceCallback(const std_srvs::Empty::Request &req,
+                                         const std_srvs::Empty::Response &res)
 {
   return true;
 }
@@ -310,4 +312,4 @@ void GazeboRosCreateIMU::IMUQueueThread()
     this->imu_queue_.callAvailable(ros::WallDuration(timeout));
   }
 }
-}
+}  // namespace gazebo


### PR DESCRIPTION
# Description

With the intent of removing the current way of setting the TF prefixes, this PR modifies the default IMU plugin to add a Tf prefix to the Frame ID field.

## Type of change

- [X] Bug fix (non-breaking change which fixes an issue)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)

# How Has This Been Tested?

```bash
roslaunch ca_gazebo create_empty_world.launch
rostopic echo /create1/imu/data/header
```

**Test Configuration**:

- [ ] Real robot
- [X] Gazebo simulation

# Checklist:

- [X] My code follows the style guidelines of this project (Travis CI is passing)
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
