### PR TITLE
Remove required flag from d435 launch

### DIFF
--- a/sensors/ca_camera/launch/realsense_d435.launch
+++ b/sensors/ca_camera/launch/realsense_d435.launch
@@ -35,11 +35,10 @@ image_proc and depth_image_proc.
 
   <group ns="d435">
     <!-- Realsense D435 nodelets -->
-    <node pkg="nodelet" type="nodelet" name="$(arg manager)" args="manager"
-          output="screen" required="$(arg required)"/>
+    <node pkg="nodelet" type="nodelet" name="$(arg manager)"
+          args="manager" output="screen"/>
     <node pkg="nodelet" type="nodelet" name="realsense2_camera"
-          args="load realsense2_camera/RealSenseNodeFactory $(arg manager)"
-          required="$(arg required)">
+          args="load realsense2_camera/RealSenseNodeFactory $(arg manager)">
 
       <rosparam command="load" file="$(find ca_camera)/config/d435.yaml"/>
 


### PR DESCRIPTION
# Description

This PR fixes an error launching the real D435 because of a missing declaration of `required`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
# Step 1
./run_command a
# Step 2
./run_another_command
```

**Test Configuration**:

- [x] Real robot
- [ ] Gazebo simulation
- [ ] Other (please specify)

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
