### PR TITLE
Use create_gazebo_models in ca_gazebo

### DIFF
--- a/ca_gazebo/package.xml
+++ b/ca_gazebo/package.xml
@@ -27,6 +27,7 @@
   <exec_depend>ca_slam</exec_depend>
   <exec_depend>ca_swarm</exec_depend>
   <exec_depend>ca_tools</exec_depend>
+  <exec_depend>create_gazebo_models</exec_depend>
   <exec_depend>gazebo_ros</exec_depend>
   <exec_depend>message_runtime</exec_depend>
   <exec_depend>nodelet</exec_depend>


### PR DESCRIPTION
# Description

Since all the models were migrated to `create_gazebo_models` we need to tell `ca_gazebo` where to look for new models.

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:

- [ ] Real robot
- [X] Gazebo simulation
- [ ] Other (please specify)

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
