### PR TITLE
Use original cartographer node

### DIFF
--- a/dependencies.txt
+++ b/dependencies.txt
@@ -4,6 +4,7 @@ ros-*-amcl
 ros-*-behaviortree-cpp-v3
 ros-*-camera-calibration
 ros-*-carrot-planner
+ros-*-cartographer-ros
 ros-*-controller-manager
 ros-*-depthimage-to-laserscan
 ros-*-diff-drive-controller

--- a/docker/create_ros_melodic_gazebo9/Dockerfile
+++ b/docker/create_ros_melodic_gazebo9/Dockerfile
@@ -17,29 +17,6 @@ RUN apt-get update && \
     gazebo9 \
     libgazebo9-dev
 
-# Install custom cartographer
-ENV CARTO_WS="/home/${USER}/catkin_ws"
-RUN mkdir ${CARTO_WS}
-WORKDIR ${CARTO_WS}
-RUN apt-get install -y \
-        ninja-build \
-        python-rosdep \
-        python-wstool \
-        stow
-RUN wstool init src && \
-    wstool merge -t src \
-        https://raw.githubusercontent.com/RoboticaUtnFrba/cartographer_ros/master/cartographer_ros.rosinstall && \
-    wstool update -t src
-RUN src/cartographer/scripts/install_proto3.sh --local
-RUN src/cartographer/scripts/install_abseil.sh
-USER ${USER}
-RUN rosdep install --from-paths src --rosdistro=${ROS1_DISTRO} -yi -r --os=ubuntu:bionic
-# Change again to root in order to install in /opt
-USER root
-RUN /bin/bash -c "source /opt/ros/${ROS1_DISTRO}/setup.bash && \
-    catkin_make_isolated --install --use-ninja --install-space /opt/ros/${ROS1_DISTRO}"
-RUN rm -rf ${CARTO_WS}
-
 # Install RTIMULib
 WORKDIR ${WS_DIR}
 ENV IMU_SCRIPT="install_rtimulib.sh"

--- a/navigation/ca_cartographer/config/mapping_2d.lua
+++ b/navigation/ca_cartographer/config/mapping_2d.lua
@@ -35,7 +35,6 @@ options = {
   imu_sampling_ratio = 1.,
   fixed_frame_pose_sampling_ratio = 1.,
   landmarks_sampling_ratio = 1.,
-  use_pose_extrapolator = true,
 }
 
 MAP_BUILDER.use_trajectory_builder_2d = true

--- a/navigation/ca_cartographer/launch/mapping_cartographer.launch
+++ b/navigation/ca_cartographer/launch/mapping_cartographer.launch
@@ -4,8 +4,7 @@
 
   <node name="cartographer_node" pkg="cartographer_ros" type="cartographer_node"
         args="-configuration_directory $(find ca_cartographer)/config
-              -configuration_basename mapping_2d.lua
-              -transform_tolerance 0.15">
+              -configuration_basename mapping_2d.lua">
 
     <env name="tf_prefix" value="$(arg ns)"/>
 
@@ -15,8 +14,7 @@
   </node>
 
   <node name="cartographer_occupancy_grid_node" pkg="cartographer_ros" type="cartographer_occupancy_grid_node"
-        args="-resolution 0.05
-              --publish_ros_map">
+        args="-resolution 0.05">
     <remap from="map" to="/map" />
   </node>
 </launch>


### PR DESCRIPTION
# Description

This PR reverts Cartographer: instead of using the customized node, we use the original which can be installed faster from APT but **it won't work with exploration**.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [X] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [X] This change requires a documentation update

# How Has This Been Tested?

<https://github.com/RoboticaUtnFrba/create_autonomy/wiki/Simultaneous-Localization-and-Mapping-(SLAM)#cartographer>

**Test Configuration**:

- [ ] Real robot
- [X] Gazebo simulation
- [ ] Other (please specify)

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
