### PR TITLE
Fix parameter name for global planners

### DIFF
--- a/navigation/ca_move_base/config/carrot_global_planner_params.yaml
+++ b/navigation/ca_move_base/config/carrot_global_planner_params.yaml
@@ -1,5 +1,5 @@
 # Move base
-base_local_planner: "carrot_planner/CarrotPlanner"
+base_global_planner: "carrot_planner/CarrotPlanner"
 
 # Move base flex
 planners:

--- a/navigation/ca_move_base/config/gbp_global_planner_params.yaml
+++ b/navigation/ca_move_base/config/gbp_global_planner_params.yaml
@@ -4,7 +4,7 @@
 # http://wiki.ros.org/global_planner
 
 # Move base
-base_local_planner: "global_planner/GlobalPlanner"
+base_global_planner: "global_planner/GlobalPlanner"
 
 # Move base flex
 planners:

--- a/navigation/ca_move_base/config/navfn_global_planner_params.yaml
+++ b/navigation/ca_move_base/config/navfn_global_planner_params.yaml
@@ -6,7 +6,7 @@
 # http://wiki.ros.org/nav_core#BaseGlobalPlanner
 
 # Move base
-base_local_planner: "navfn/NavfnROS"
+base_global_planner: "navfn/NavfnROS"
 
 # Move base flex
 planners:

--- a/navigation/ca_move_base/config/sbpl_global_planner_params.yaml
+++ b/navigation/ca_move_base/config/sbpl_global_planner_params.yaml
@@ -6,7 +6,7 @@
 # http://wiki.ros.org/nav_core#BaseGlobalPlanner
 
 # Move base
-base_local_planner: "SBPLLatticePlanner"
+base_global_planner: "SBPLLatticePlanner"
 
 # Move base flex
 controllers:


### PR DESCRIPTION
# Description

An error reported by a student led me to realize that the global planners were not being set correctly for `move_base` nor `move_base_flex`.
This PR sets the `base_global_planner` parameter for global planners.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes.
Provide instructions so we can reproduce. Also list any relevant details for your test configuration.

```bash
export NAVIGATION=mbf 
export LOCALIZATION=slam 
export LASER=rplidar 
export RVIZ=true 
export NODELET=false 
roslaunch ca_gazebo create_house.launch
```

**Test Configuration**:

- [ ] Real robot
- [x] Gazebo simulation
- [ ] Other (please specify)

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
