### PR TITLE
explore_lite: respawn in false

### DIFF
--- a/navigation/ca_mapping_exploration/launch/explore_lite.launch
+++ b/navigation/ca_mapping_exploration/launch/explore_lite.launch
@@ -3,7 +3,7 @@
   <arg name="ns" default="create$(arg id)" doc="Namespace of the robot. By default: create1."/>
 
   <node pkg="explore_lite" type="explore" name="explore"
-        output="screen" respawn="true" ns="$(arg ns)">
+        output="screen" respawn="false" ns="$(arg ns)">
     <rosparam command="load" file="$(find ca_mapping_exploration)/config/explore_lite.yaml"/>
     <param name="robot_base_frame" value="$(arg ns)/base_footprint"/>
   </node>


### PR DESCRIPTION
# Description

If you want to kill `explore_lite` its current configuration doesn't allow so. This change fixes it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

**Test Configuration**:

- [ ] Real robot
- [x] Gazebo simulation
- [ ] Other (please specify)

# Checklist:

- [x] My code follows the style guidelines of this project (Travis CI is passing)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
